### PR TITLE
feat: add Vercel Sandbox provider

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,4 +34,8 @@ jobs:
           DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
         run: npm run test:e2e:matrix

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .env
 .env.*
 coverage
+.idea
+.plan-*.md

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ Every sandbox supports: `run()`, `runAsync()`, `gitClone()`, `openPort()`, `getP
 
 Vercel sandboxes use runtime snapshots instead of pre-built images — call `sandbox.snapshot()` to capture state and pass the returned id via `provider.snapshotId` on the next run.
 
+Vercel also requires ports to be declared at create time via `provider.ports` — `openPort()` is a no-op at runtime, so any port the agent (or your own code) will listen on must be listed up front:
+
+```ts
+const sandbox = new Sandbox("vercel", {
+  provider: {
+    snapshotId: process.env.VERCEL_SNAPSHOT_ID!,
+    ports: [4096], // e.g. opencode; codex/claude-code use 43180
+  },
+});
+```
+
 ## Skills
 
 Attach GitHub repos as agent skills. They're cloned into the sandbox and surfaced to the agent:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ await sandbox.delete();
 Providers are mix-and-match:
 
 - **Agents** — [`claude-code`](./src/agents/providers/claude-code.ts), [`opencode`](./src/agents/providers/opencode.ts), [`codex`](./src/agents/providers/codex.ts)
-- **Sandboxes** — [`local-docker`](./src/sandboxes/providers/local-docker.ts), [`e2b`](./src/sandboxes/providers/e2b.ts), [`modal`](./src/sandboxes/providers/modal.ts), [`daytona`](./src/sandboxes/providers/daytona.ts)
+- **Sandboxes** — [`local-docker`](./src/sandboxes/providers/local-docker.ts), [`e2b`](./src/sandboxes/providers/e2b.ts), [`modal`](./src/sandboxes/providers/modal.ts), [`daytona`](./src/sandboxes/providers/daytona.ts), [`vercel`](./src/sandboxes/providers/vercel.ts)
 
 Swap either one and your app code stays the same.
 
@@ -124,16 +124,19 @@ new Agent("codex", { sandbox, cwd: "/workspace", approvalMode: "auto" });
 
 ## Sandboxes
 
-Four sandbox providers are supported. Each gives you an isolated environment with the same interface:
+Five sandbox providers are supported. Each gives you an isolated environment with the same interface:
 
-| Provider       | What it is             | Auth                                    |
-| -------------- | ---------------------- | --------------------------------------- |
-| `local-docker` | Local Docker container | Docker daemon                           |
-| `e2b`          | Cloud micro-VM         | `E2B_API_KEY`                           |
-| `modal`        | Cloud container        | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` |
-| `daytona`      | Cloud dev environment  | `DAYTONA_API_KEY`                       |
+| Provider       | What it is             | Auth                                                    |
+| -------------- | ---------------------- | ------------------------------------------------------- |
+| `local-docker` | Local Docker container | Docker daemon                                           |
+| `e2b`          | Cloud micro-VM         | `E2B_API_KEY`                                           |
+| `modal`        | Cloud container        | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET`                 |
+| `daytona`      | Cloud dev environment  | `DAYTONA_API_KEY`                                       |
+| `vercel`       | Ephemeral cloud VM     | `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` |
 
 Every sandbox supports: `run()`, `runAsync()`, `gitClone()`, `openPort()`, `getPreviewLink()`, `snapshot()`, `stop()`, `delete()`.
+
+Vercel sandboxes use runtime snapshots instead of pre-built images — call `sandbox.snapshot()` to capture state and pass the returned id via `provider.snapshotId` on the next run.
 
 ## Skills
 
@@ -348,6 +351,7 @@ The [`examples/`](./examples) directory has short, runnable scripts that each de
 | [`multimodal.ts`](./examples/multimodal.ts)                     | Send images to the agent      |
 | [`custom-image.ts`](./examples/custom-image.ts)                 | Build a custom sandbox image  |
 | [`cloud-sandbox.ts`](./examples/cloud-sandbox.ts)               | Use E2B, Modal, or Daytona    |
+| [`basic-vercel.ts`](./examples/basic-vercel.ts)                 | Use a Vercel sandbox          |
 | [`git-clone.ts`](./examples/git-clone.ts)                       | Clone a repo into the sandbox |
 
 All examples import from `"agentbox-sdk"` like a normal dependency. Run them with:

--- a/examples/basic-vercel.ts
+++ b/examples/basic-vercel.ts
@@ -1,0 +1,29 @@
+/**
+ * Basic Vercel sandbox usage.
+ * Requires: VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID
+ */
+
+import { Sandbox } from "agentbox-sdk";
+
+const sandbox = new Sandbox("vercel", {
+  tags: { example: "basic-vercel" },
+  provider: {
+    runtime: "node24",
+    timeoutMs: 120_000,
+    token: process.env.VERCEL_TOKEN,
+    teamId: process.env.VERCEL_TEAM_ID,
+    projectId: process.env.VERCEL_PROJECT_ID,
+  },
+});
+
+// Vercel sandboxes run under /vercel/sandbox by default and cannot use
+// an arbitrary workspace root like the other providers.
+await sandbox.gitClone({
+  repoUrl: "https://github.com/octocat/Hello-World.git",
+  targetDir: "/vercel/sandbox/hello-world",
+});
+
+const result = await sandbox.run("ls -la /vercel/sandbox/hello-world");
+console.log(result.stdout);
+
+await sandbox.delete();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.161.0",
+        "@vercel/sandbox": "2.0.0-beta.13",
         "dockerode": "^4.0.10",
         "e2b": "^2.19.0",
         "eventsource-parser": "^3.0.6",
@@ -1468,6 +1469,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
@@ -1482,6 +1484,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
       "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1"
       },
@@ -1494,6 +1497,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1506,6 +1510,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -1526,6 +1531,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -1535,6 +1541,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
       "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
@@ -3432,7 +3439,8 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3444,7 +3452,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.2",
@@ -3715,6 +3724,44 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/sandbox": {
+      "version": "2.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.0.0-beta.13.tgz",
+      "integrity": "sha512-p05ShlOrrL4C2OnR68AEksP3HUaXsvgIlwAOu8NQjsk2qNoXaq4gCKQscHOb44/TdLQGT0EkdADxQIzPY8Eoug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0",
+        "@workflow/serde": "4.1.0-beta.2",
+        "async-retry": "1.3.3",
+        "jsonlines": "0.1.1",
+        "ms": "2.1.3",
+        "picocolors": "^1.1.1",
+        "tar-stream": "3.1.7",
+        "undici": "^7.16.0",
+        "xdg-app-paths": "5.1.0",
+        "zod": "3.24.4"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
@@ -3845,6 +3892,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "license": "Apache-2.0"
+    },
     "node_modules/abort-controller-x": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
@@ -3874,6 +3927,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -3883,6 +3937,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3937,6 +3992,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -4656,6 +4720,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4711,6 +4776,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -4753,6 +4819,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
@@ -4782,6 +4849,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -4864,7 +4932,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -4890,7 +4959,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5272,6 +5342,7 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -5382,13 +5453,20 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5891,6 +5969,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5997,8 +6084,7 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -6160,6 +6246,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6245,6 +6332,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -6916,6 +7012,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -6926,6 +7031,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7689,6 +7795,30 @@
         }
       }
     },
+    "node_modules/xdg-app-paths": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
+      "integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "xdg-portable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7740,6 +7870,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.161.0",
+    "@vercel/sandbox": "2.0.0-beta.13",
     "dockerode": "^4.0.10",
     "e2b": "^2.19.0",
     "eventsource-parser": "^3.0.6",
@@ -88,6 +89,7 @@
     "modal",
     "daytona",
     "docker",
+    "vercel",
     "typescript",
     "bun"
   ]

--- a/src/agents/providers/claude-code.ts
+++ b/src/agents/providers/claude-code.ts
@@ -612,12 +612,13 @@ function buildLocalSdkUrl(
 
 async function connectRemoteTransport(
   url: string,
+  headers: Record<string, string> = {},
 ): Promise<SharedSdkWsConnection> {
   const startedAt = Date.now();
   let lastError: unknown;
 
   while (Date.now() - startedAt < 30_000) {
-    const client = new SharedSdkWsConnection(url);
+    const client = new SharedSdkWsConnection(url, headers);
     try {
       await Promise.race([
         client.start(),
@@ -640,11 +641,14 @@ async function connectRemoteTransport(
   );
 }
 
-async function canConnectToRemoteRelay(previewUrl: string): Promise<boolean> {
+async function canConnectToRemoteRelay(
+  previewUrl: string,
+  headers: Record<string, string> = {},
+): Promise<boolean> {
   const parsed = new URL(toWebSocketUrl(previewUrl));
   parsed.searchParams.set("role", "claude");
   parsed.searchParams.set("runId", "__probe__");
-  const client = new SharedSdkWsConnection(parsed.toString());
+  const client = new SharedSdkWsConnection(parsed.toString(), headers);
   try {
     await Promise.race([
       client.start(),
@@ -686,7 +690,7 @@ async function ensureSharedRemoteConnection(
 
   const created = (async () => {
     const url = toSharedHostWebSocketUrl(previewUrl);
-    const connection = await connectRemoteTransport(url);
+    const connection = await connectRemoteTransport(url, sandbox.previewHeaders);
     return { previewUrl, connection };
   })();
 
@@ -706,8 +710,9 @@ async function ensureRemoteRelay(
   const sandbox = request.options.sandbox!;
   await sandbox.openPort(REMOTE_SDK_RELAY_PORT);
   const previewUrl = await sandbox.getPreviewLink(REMOTE_SDK_RELAY_PORT);
+  const previewHeaders = sandbox.previewHeaders;
 
-  if (await canConnectToRemoteRelay(previewUrl)) {
+  if (await canConnectToRemoteRelay(previewUrl, previewHeaders)) {
     return {
       relayPort: REMOTE_SDK_RELAY_PORT,
       relayPath: REMOTE_SDK_RELAY_PATH,
@@ -744,7 +749,7 @@ async function ensureRemoteRelay(
 
   const startedAt = Date.now();
   while (Date.now() - startedAt < 30_000) {
-    if (await canConnectToRemoteRelay(previewUrl)) {
+    if (await canConnectToRemoteRelay(previewUrl, previewHeaders)) {
       return {
         relayPort: REMOTE_SDK_RELAY_PORT,
         relayPath: REMOTE_SDK_RELAY_PATH,

--- a/src/agents/providers/codex.ts
+++ b/src/agents/providers/codex.ts
@@ -502,13 +502,16 @@ function toRemoteCodexWebSocketUrl(url: string): string {
   return parsed.toString();
 }
 
-async function connectRemoteCodexAppServer(url: string) {
+async function connectRemoteCodexAppServer(
+  url: string,
+  headers: Record<string, string> = {},
+) {
   const startedAt = Date.now();
   let lastError: unknown;
 
   while (Date.now() - startedAt < 30_000) {
     try {
-      return await connectJsonRpcWebSocket(url);
+      return await connectJsonRpcWebSocket(url, { headers });
     } catch (error) {
       lastError = error;
       await sleep(250);
@@ -696,6 +699,7 @@ async function createRuntime(
 
       const transport = await connectRemoteCodexAppServer(
         toRemoteCodexWebSocketUrl(previewUrl),
+        sandbox.previewHeaders,
       );
       return {
         source: transport.source,

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -27,11 +27,17 @@ import { installSkills, prepareSkillArtifacts } from "../config/skills";
 import { buildOpenCodeSubagentConfig } from "../config/subagents";
 import { fetchJson, streamSse } from "../transports/app-server";
 import { spawnCommand, waitForHttpReady } from "../transports/spawn";
-import { getAvailablePort } from "../../shared/network";
+import { getAvailablePort, sleep } from "../../shared/network";
 import { shellQuote } from "../../shared/shell";
 
 type OpenCodeRuntime = {
   baseUrl: string;
+  /**
+   * Headers to attach to every request hitting `baseUrl`. Sandbox-backed
+   * runtimes pass through `sandbox.previewHeaders` here so providers like
+   * Vercel can inject their Deployment Protection bypass token.
+   */
+  previewHeaders: Record<string, string>;
   cleanup: () => Promise<void>;
   raw: unknown;
 };
@@ -220,6 +226,7 @@ async function ensureSandboxOpenCodeServer(
   const port = SANDBOX_OPENCODE_PORT;
 
   await sandbox.openPort(port);
+  const previewHeaders = sandbox.previewHeaders;
 
   const healthCheck = await sandbox.run(
     `curl -fsS http://127.0.0.1:${port}/global/health >/dev/null 2>&1`,
@@ -230,6 +237,7 @@ async function ensureSandboxOpenCodeServer(
     const baseUrl = (await sandbox.getPreviewLink(port)).replace(/\/$/, "");
     return {
       baseUrl,
+      previewHeaders,
       cleanup: async () => {},
       raw: { baseUrl, port, reused: true },
     };
@@ -314,13 +322,39 @@ async function ensureSandboxOpenCodeServer(
     );
   }
 
+  // Poll opencode readiness from INSIDE the sandbox via curl localhost.
+  // We can't poll the preview URL because some sandbox proxies (Vercel's
+  // in particular) return a synthetic 200 OK with an empty body for
+  // requests to ports whose listeners haven't started accepting
+  // connections yet — a trivial fetch-based readiness check would get a
+  // false positive while opencode is still doing its first-run DB
+  // migration, and the subsequent POST /session would race the migration
+  // and come back with the same empty 200.
+  const readyDeadline = Date.now() + SANDBOX_OPENCODE_READY_TIMEOUT_MS;
+  let ready = false;
+  while (Date.now() < readyDeadline) {
+    const probe = await sandbox.run(
+      `curl -fsS http://127.0.0.1:${port}/global/health >/dev/null 2>&1`,
+      { cwd: options.cwd, timeoutMs: 5_000 },
+    );
+    if (probe.exitCode === 0) {
+      ready = true;
+      break;
+    }
+    await sleep(500);
+  }
+  if (!ready) {
+    await target.cleanup().catch(() => undefined);
+    throw new Error(
+      `OpenCode server did not become ready within ${SANDBOX_OPENCODE_READY_TIMEOUT_MS}ms.`,
+    );
+  }
+
   const baseUrl = (await sandbox.getPreviewLink(port)).replace(/\/$/, "");
-  await waitForHttpReady(`${baseUrl}/global/health`, {
-    timeoutMs: SANDBOX_OPENCODE_READY_TIMEOUT_MS,
-  });
 
   return {
     baseUrl,
+    previewHeaders,
     cleanup: async () => {
       await target.cleanup().catch(() => undefined);
     },
@@ -394,6 +428,7 @@ async function createLocalRuntime(
 
   return {
     baseUrl,
+    previewHeaders: {},
     cleanup: async () => {
       await processHandle.kill();
       await target.cleanup();
@@ -441,7 +476,10 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"opencode"> {
             `${runtime.baseUrl}/session`,
             {
               method: "POST",
-              headers: { "content-type": "application/json" },
+              headers: {
+                "content-type": "application/json",
+                ...runtime.previewHeaders,
+              },
               body: JSON.stringify({
                 title: `AgentBox ${request.runId}`,
               }),
@@ -458,6 +496,7 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"opencode"> {
       sseTask = (async () => {
         try {
           for await (const event of streamSse(`${runtime.baseUrl}/event`, {
+            headers: runtime.previewHeaders,
             signal: sseAbort.signal,
           })) {
             let payload: unknown = event.data;
@@ -502,7 +541,10 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"opencode"> {
                   `${runtime.baseUrl}/session/${sessionId}/permissions/${permissionEvent.requestId}`,
                   {
                     method: "POST",
-                    headers: { "content-type": "application/json" },
+                    headers: {
+                      "content-type": "application/json",
+                      ...runtime.previewHeaders,
+                    },
                     body: JSON.stringify({
                       response:
                         response.decision === "allow"
@@ -551,7 +593,10 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"opencode"> {
         `${runtime.baseUrl}/session/${sessionId}/message`,
         {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            ...runtime.previewHeaders,
+          },
           body: JSON.stringify({
             ...(request.run.model
               ? { model: toOpenCodeModel(request.run.model) }

--- a/src/agents/transports/app-server.ts
+++ b/src/agents/transports/app-server.ts
@@ -18,7 +18,22 @@ export async function fetchJson<T>(
     throw new Error(`Request to ${url} failed with ${response.status}.`);
   }
 
-  return (await response.json()) as T;
+  const text = await response.text();
+  if (text.length === 0) {
+    throw new Error(
+      `Request to ${url} returned status ${response.status} with an empty body.`,
+    );
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    const preview = text.length > 200 ? `${text.slice(0, 200)}…` : text;
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not parse JSON response from ${url} (status ${response.status}): ${cause}. Body: ${preview}`,
+    );
+  }
 }
 
 export async function* streamSse(
@@ -84,9 +99,10 @@ export interface JsonRpcWebSocketTransport {
 
 export async function connectJsonRpcWebSocket(
   url: string,
+  options?: { headers?: Record<string, string> },
 ): Promise<JsonRpcWebSocketTransport> {
   const notifications = new AsyncQueue<string>();
-  const socket = new WebSocket(url);
+  const socket = new WebSocket(url, { headers: options?.headers });
 
   await new Promise<void>((resolve, reject) => {
     const cleanup = () => {

--- a/src/agents/transports/sdk-ws.ts
+++ b/src/agents/transports/sdk-ws.ts
@@ -200,14 +200,17 @@ export class SdkWsClient implements SdkWsTransport {
   private readonly messagesQueue = new AsyncQueue<SdkWsMessage>();
   private readonly pendingResponses = new Map<string, PendingResponse>();
 
-  constructor(private readonly url: string) {}
+  constructor(
+    private readonly url: string,
+    private readonly headers: Record<string, string> = {},
+  ) {}
 
   async start(): Promise<void> {
     if (this.socket?.readyState === WebSocket.OPEN) {
       return;
     }
 
-    const socket = new WebSocket(this.url);
+    const socket = new WebSocket(this.url, { headers: this.headers });
     this.socket = socket;
 
     socket.on("message", (data) => {
@@ -412,14 +415,17 @@ export class SharedSdkWsConnection {
   private readonly channels = new Map<string, SharedSdkWsChannel>();
   private readonly pendingMessages = new Map<string, SdkWsMessage[]>();
 
-  constructor(private readonly url: string) {}
+  constructor(
+    private readonly url: string,
+    private readonly headers: Record<string, string> = {},
+  ) {}
 
   async start(): Promise<void> {
     if (this.socket?.readyState === WebSocket.OPEN) {
       return;
     }
 
-    const socket = new WebSocket(this.url);
+    const socket = new WebSocket(this.url, { headers: this.headers });
     this.socket = socket;
 
     socket.on("message", (data) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,7 @@ function isSandboxProviderName(value: string): value is SandboxProviderName {
     value === "local-docker" ||
     value === "modal" ||
     value === "daytona" ||
+    value === "vercel" ||
     value === "e2b"
   );
 }
@@ -117,8 +118,8 @@ function printHelp(): void {
   process.stdout.write(`agentbox
 
 Usage:
-  agentbox image build --provider <local-docker|modal|daytona|e2b> --preset <browser-agent|computer-use>
-  agentbox image build --provider <local-docker|modal|daytona|e2b> --file <path>
+  agentbox image build --provider <local-docker|modal|daytona|vercel|e2b> --preset <browser-agent|computer-use>
+  agentbox image build --provider <local-docker|modal|daytona|vercel|e2b> --file <path>
 
 Options:
   --image-name <name>        Override the built artifact name
@@ -127,6 +128,7 @@ Options:
 Environment:
   Modal: MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, MODAL_ENVIRONMENT?, MODAL_ENDPOINT?
   Daytona: DAYTONA_API_KEY or DAYTONA_JWT_TOKEN, DAYTONA_ORGANIZATION_ID?, DAYTONA_API_URL?, DAYTONA_TARGET?
+  Vercel: VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID
   E2B: E2B_API_KEY, E2B_DOMAIN?, E2B_ACCESS_TOKEN?
 `);
 }

--- a/src/sandbox-images/build.ts
+++ b/src/sandbox-images/build.ts
@@ -64,6 +64,11 @@ export async function buildSandboxImage(
       return buildDaytonaSnapshot(definition, options);
     case "e2b":
       return buildE2bTemplate(definition, options);
+    default:
+      throw new Error(
+        `Image building is not supported for provider "${options.provider}". ` +
+          `Vercel sandboxes use runtime snapshots instead — see Sandbox.snapshot().`,
+      );
   }
 }
 

--- a/src/sandboxes/Sandbox.ts
+++ b/src/sandboxes/Sandbox.ts
@@ -2,6 +2,7 @@ import { DaytonaSandboxAdapter } from "./providers/daytona";
 import { E2bSandboxAdapter } from "./providers/e2b";
 import { LocalDockerSandboxAdapter } from "./providers/local-docker";
 import { ModalSandboxAdapter } from "./providers/modal";
+import { VercelSandboxAdapter } from "./providers/vercel";
 import type {
   AsyncCommandHandle,
   CommandOptions,
@@ -32,6 +33,10 @@ function createSandboxAdapter<P extends SandboxProviderName>(
     case "daytona":
       return new DaytonaSandboxAdapter(
         options as SandboxOptions<"daytona">,
+      ) as unknown as SandboxAdapter<P, SandboxOptions<P>, SandboxRaw<P>>;
+    case "vercel":
+      return new VercelSandboxAdapter(
+        options as SandboxOptions<"vercel">,
       ) as unknown as SandboxAdapter<P, SandboxOptions<P>, SandboxRaw<P>>;
     case "e2b":
       return new E2bSandboxAdapter(
@@ -119,5 +124,20 @@ export class Sandbox<P extends SandboxProviderName = SandboxProviderName> {
 
   async getPreviewLink(port: number): Promise<string> {
     return this.adapter.getPreviewLink(port);
+  }
+
+  get previewHeaders(): Record<string, string> {
+    return this.adapter.previewHeaders;
+  }
+
+  async uploadFile(
+    content: Buffer | string,
+    targetPath: string,
+  ): Promise<void> {
+    return this.adapter.uploadFile(content, targetPath);
+  }
+
+  async downloadFile(sourcePath: string): Promise<Buffer> {
+    return this.adapter.downloadFile(sourcePath);
   }
 }

--- a/src/sandboxes/base.ts
+++ b/src/sandboxes/base.ts
@@ -46,6 +46,24 @@ export abstract class SandboxAdapter<
   abstract openPort(port: number): Promise<void>;
   abstract getPreviewLink(port: number): Promise<string>;
 
+  async uploadFile(
+    _content: Buffer | string,
+    _targetPath: string,
+  ): Promise<void> {
+    void _content;
+    void _targetPath;
+    throw new Error(
+      `uploadFile is not supported by the ${this.provider} provider.`,
+    );
+  }
+
+  async downloadFile(_sourcePath: string): Promise<Buffer> {
+    void _sourcePath;
+    throw new Error(
+      `downloadFile is not supported by the ${this.provider} provider.`,
+    );
+  }
+
   protected async ensureProvisioned(): Promise<void> {
     if (this.provisioned) {
       return;
@@ -69,6 +87,15 @@ export abstract class SandboxAdapter<
 
   get workingDir(): string {
     return this.options.workingDir ?? "/workspace";
+  }
+
+  /**
+   * Headers that callers should attach to HTTP / WebSocket requests they make
+   * against this sandbox's preview URL. Default is empty; providers like
+   * Vercel override this to inject Deployment Protection bypass tokens.
+   */
+  get previewHeaders(): Record<string, string> {
+    return {};
   }
 
   getMergedEnv(extra?: Record<string, string>): Record<string, string> {

--- a/src/sandboxes/providers/vercel.ts
+++ b/src/sandboxes/providers/vercel.ts
@@ -1,0 +1,401 @@
+import { Sandbox as VercelSandbox } from "@vercel/sandbox";
+
+import { SandboxAdapter } from "../base";
+import type {
+  AsyncCommandHandle,
+  CommandEvent,
+  CommandOptions,
+  CommandResult,
+  SandboxDescriptor,
+  SandboxListOptions,
+  VercelSandboxOptions,
+} from "../types";
+import { AsyncQueue } from "../../shared/async-queue";
+import { toShellCommand } from "../../shared/shell";
+import { resolveSandboxResources } from "../image-utils";
+
+// @vercel/sandbox uses static-method-style API (VercelSandbox.create/list/get)
+// so there is no client instance to expose — only the provisioned sandbox.
+export type VercelRaw = {
+  sandbox?: VercelSandbox;
+};
+
+// Vercel's list endpoint accepts at most ONE tag filter at a time
+// (`bad_request: Only one tag filter is supported at a time`). To support
+// the broader peer convention of filtering by multiple tags, we send the
+// first entry server-side and intersect the rest client-side.
+function pickFirstTag(
+  tags: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!tags) return undefined;
+  const entries = Object.entries(tags);
+  if (entries.length === 0) return undefined;
+  const [key, value] = entries[0]!;
+  return { [key]: value };
+}
+
+function matchesAllTags(
+  candidateTags: Record<string, string> | undefined,
+  required: Record<string, string>,
+): boolean {
+  return Object.entries(required).every(
+    ([key, value]) => candidateTags?.[key] === value,
+  );
+}
+
+function describeVercelApiError(error: unknown, action: string): Error {
+  if (
+    error &&
+    typeof error === "object" &&
+    "response" in error &&
+    error.response instanceof Response
+  ) {
+    const apiError = error as Error & {
+      response: Response;
+      json?: unknown;
+      text?: string;
+    };
+    const status = apiError.response.status;
+    const body =
+      apiError.json !== undefined
+        ? JSON.stringify(apiError.json)
+        : (apiError.text ?? "");
+    return new Error(
+      `Vercel ${action} failed with HTTP ${status}: ${body || apiError.message}`,
+    );
+  }
+
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function getCredentials(options: VercelSandboxOptions) {
+  const token = options.provider?.token ?? process.env.VERCEL_TOKEN;
+  const teamId = options.provider?.teamId ?? process.env.VERCEL_TEAM_ID;
+  const projectId =
+    options.provider?.projectId ?? process.env.VERCEL_PROJECT_ID;
+
+  if (token && teamId && projectId) {
+    return { token, teamId, projectId };
+  }
+
+  return {};
+}
+
+export class VercelSandboxAdapter extends SandboxAdapter<
+  "vercel",
+  VercelSandboxOptions,
+  VercelRaw
+> {
+  private sandbox?: VercelSandbox;
+
+  constructor(options: VercelSandboxOptions) {
+    super(options);
+  }
+
+  get provider(): "vercel" {
+    return "vercel";
+  }
+
+  get raw(): VercelRaw {
+    return { sandbox: this.sandbox };
+  }
+
+  get id(): string | undefined {
+    return this.sandbox?.name;
+  }
+
+  override get workingDir(): string {
+    return this.options.workingDir ?? "/vercel/sandbox";
+  }
+
+  override get previewHeaders(): Record<string, string> {
+    const token = this.options.provider?.protectionBypass;
+    return token ? { "x-vercel-protection-bypass": token } : {};
+  }
+
+  protected async provision(): Promise<void> {
+    const existing = await this.findExistingSandbox();
+    if (existing) {
+      this.sandbox = existing;
+      return;
+    }
+
+    const credentials = getCredentials(this.options);
+    const provider = this.options.provider;
+    const snapshotId = provider?.snapshotId;
+    const timeout = provider?.timeoutMs ?? 120_000;
+    const runtime = provider?.runtime ?? "node24";
+    const resources = resolveSandboxResources(this.options.resources);
+    const vcpus = resources?.cpu ? { resources: { vcpus: resources.cpu } } : {};
+
+    const base = {
+      ...credentials,
+      timeout,
+      env: this.getMergedEnv(),
+      ...vcpus,
+      tags: this.getTags(),
+      ...(provider?.ports?.length ? { ports: provider.ports } : {}),
+    };
+
+    let sandbox: VercelSandbox & AsyncDisposable;
+    if (snapshotId) {
+      // Snapshot sources carry their own runtime; the Vercel SDK rejects
+      // `runtime` alongside a snapshot source, so we don't forward it here.
+      sandbox = await VercelSandbox.create({
+        ...base,
+        source: { type: "snapshot", snapshotId },
+      });
+    } else if (provider?.gitSource) {
+      const git = provider.gitSource;
+      const source = {
+        type: "git" as const,
+        url: git.url,
+        depth: git.depth,
+        revision: git.revision,
+        ...(git.username && git.password
+          ? { username: git.username, password: git.password }
+          : {}),
+      };
+      sandbox = await VercelSandbox.create({ ...base, runtime, source });
+    } else {
+      sandbox = await VercelSandbox.create({ ...base, runtime });
+    }
+
+    this.sandbox = sandbox;
+    if (this.workingDir !== "/vercel/sandbox") {
+      await sandbox.runCommand({
+        cmd: "mkdir",
+        args: ["-p", this.workingDir],
+        sudo: true,
+      });
+    }
+  }
+
+  async run(
+    command: string | string[],
+    options?: CommandOptions,
+  ): Promise<CommandResult> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+
+    const result = await sandbox.runCommand({
+      cmd: "sh",
+      args: ["-lc", toShellCommand(command)],
+      cwd: options?.cwd ?? this.workingDir,
+      env: this.getMergedEnv(options?.env),
+    });
+
+    const [stdout, stderr] = await Promise.all([
+      result.stdout(),
+      result.stderr(),
+    ]);
+
+    return {
+      exitCode: result.exitCode,
+      stdout,
+      stderr,
+      combinedOutput: `${stdout}${stderr}`,
+      raw: result,
+    };
+  }
+
+  async runAsync(
+    command: string | string[],
+    options?: CommandOptions,
+  ): Promise<AsyncCommandHandle> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+
+    const cmd = await sandbox.runCommand({
+      cmd: "sh",
+      args: ["-lc", toShellCommand(command)],
+      cwd: options?.cwd ?? this.workingDir,
+      env: this.getMergedEnv(options?.env),
+      detached: true,
+    });
+
+    const queue = new AsyncQueue<CommandEvent>();
+    let stdout = "";
+    let stderr = "";
+
+    const completion = (async () => {
+      for await (const log of cmd.logs()) {
+        if (log.stream === "stdout") {
+          stdout += log.data;
+          queue.push({
+            type: "stdout",
+            chunk: log.data,
+            timestamp: new Date().toISOString(),
+          });
+        } else {
+          stderr += log.data;
+          queue.push({
+            type: "stderr",
+            chunk: log.data,
+            timestamp: new Date().toISOString(),
+          });
+        }
+      }
+
+      const finished = await cmd.wait();
+      const exitCode = finished.exitCode;
+
+      queue.push({
+        type: "exit",
+        exitCode,
+        timestamp: new Date().toISOString(),
+      });
+      queue.finish();
+
+      return {
+        exitCode,
+        stdout,
+        stderr,
+        combinedOutput: `${stdout}${stderr}`,
+        raw: finished,
+      } satisfies CommandResult;
+    })().catch((error) => {
+      queue.fail(error);
+      throw error;
+    });
+
+    return {
+      id: cmd.cmdId,
+      raw: cmd,
+      wait: () => completion,
+      kill: async () => {
+        await cmd.kill();
+      },
+      [Symbol.asyncIterator]: () => queue[Symbol.asyncIterator](),
+    };
+  }
+
+  async list(options?: SandboxListOptions): Promise<SandboxDescriptor[]> {
+    const credentials = getCredentials(this.options);
+    const filterTags = options?.tags ?? this.getTags();
+    let result;
+    try {
+      result = await VercelSandbox.list({
+        ...credentials,
+        tags: pickFirstTag(filterTags),
+      });
+    } catch (error) {
+      throw describeVercelApiError(error, "list sandboxes");
+    }
+
+    return result.sandboxes
+      .filter(
+        (s: { tags?: Record<string, string> }) =>
+          matchesAllTags(s.tags, filterTags),
+      )
+      .map(
+        (s: {
+          name: string;
+          status: string;
+          createdAt: number;
+          tags?: Record<string, string>;
+        }) => ({
+          provider: this.provider,
+          id: s.name,
+          state: s.status,
+          tags: s.tags ?? {},
+          createdAt: new Date(s.createdAt).toISOString(),
+          raw: s,
+        }),
+      );
+  }
+
+  async snapshot(): Promise<string | null> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+    const snap = await sandbox.snapshot();
+    return snap.snapshotId;
+  }
+
+  async stop(): Promise<void> {
+    const sandbox = this.sandbox;
+    if (!sandbox) {
+      return;
+    }
+
+    await sandbox.stop();
+    this.sandbox = undefined;
+  }
+
+  async delete(): Promise<void> {
+    await this.stop();
+  }
+
+  async openPort(_port: number): Promise<void> {
+    // Vercel sandboxes expose ports declared at create time via the SDK;
+    // there is no runtime equivalent to Docker port publishing.
+    void _port;
+  }
+
+  async getPreviewLink(port: number): Promise<string> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+    return sandbox.domain(port);
+  }
+
+  async uploadFile(
+    content: Buffer | string,
+    targetPath: string,
+  ): Promise<void> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+    const data =
+      typeof content === "string" ? content : new Uint8Array(content);
+    await sandbox.writeFiles([{ path: targetPath, content: data }]);
+  }
+
+  async downloadFile(sourcePath: string): Promise<Buffer> {
+    await this.ensureProvisioned();
+    const sandbox = this.requireSandbox();
+    const result = await sandbox.readFileToBuffer({ path: sourcePath });
+    if (!result) {
+      throw new Error(`File not found in Vercel sandbox: ${sourcePath}`);
+    }
+    return result;
+  }
+
+  private getTags(): Record<string, string> {
+    return {
+      "agentbox.provider": this.provider,
+      ...(this.options.tags ?? {}),
+    };
+  }
+
+  private async findExistingSandbox(): Promise<VercelSandbox | undefined> {
+    const credentials = getCredentials(this.options);
+    const fullTags = this.getTags();
+    let result;
+    try {
+      result = await VercelSandbox.list({
+        ...credentials,
+        tags: pickFirstTag(fullTags),
+      });
+    } catch (error) {
+      throw describeVercelApiError(error, "list sandboxes");
+    }
+    const match = result.sandboxes.find(
+      (s: {
+        name: string;
+        status: string;
+        tags?: Record<string, string>;
+      }) => s.status === "running" && matchesAllTags(s.tags, fullTags),
+    );
+    if (!match) {
+      return undefined;
+    }
+    return VercelSandbox.get({ ...credentials, name: match.name });
+  }
+
+  private requireSandbox(): VercelSandbox {
+    if (!this.sandbox) {
+      throw new Error("Vercel sandbox has not been provisioned.");
+    }
+
+    return this.sandbox;
+  }
+}

--- a/src/sandboxes/providers/vercel.ts
+++ b/src/sandboxes/providers/vercel.ts
@@ -68,6 +68,29 @@ function describeVercelApiError(error: unknown, action: string): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+async function wrapVercelApiError<T>(
+  action: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    throw describeVercelApiError(error, action);
+  }
+}
+
+function buildTimeoutSignal(
+  timeoutMs: number | undefined,
+): AbortSignal | undefined {
+  if (!timeoutMs || timeoutMs <= 0) return undefined;
+  return AbortSignal.timeout(timeoutMs);
+}
+
+// `CommandOptions.pty` is not supported by the Vercel Sandbox SDK —
+// `RunCommandParams` has no PTY flag. Callers that request it (e.g.
+// claude-code) continue to work because they do not strictly require a
+// TTY; we silently run non-PTY, matching daytona's behavior.
+
 function getCredentials(options: VercelSandboxOptions) {
   const token = options.provider?.token ?? process.env.VERCEL_TOKEN;
   const teamId = options.provider?.teamId ?? process.env.VERCEL_TEAM_ID;
@@ -137,37 +160,40 @@ export class VercelSandboxAdapter extends SandboxAdapter<
       ...(provider?.ports?.length ? { ports: provider.ports } : {}),
     };
 
-    let sandbox: VercelSandbox & AsyncDisposable;
-    if (snapshotId) {
-      // Snapshot sources carry their own runtime; the Vercel SDK rejects
-      // `runtime` alongside a snapshot source, so we don't forward it here.
-      sandbox = await VercelSandbox.create({
-        ...base,
-        source: { type: "snapshot", snapshotId },
-      });
-    } else if (provider?.gitSource) {
-      const git = provider.gitSource;
-      const source = {
-        type: "git" as const,
-        url: git.url,
-        depth: git.depth,
-        revision: git.revision,
-        ...(git.username && git.password
-          ? { username: git.username, password: git.password }
-          : {}),
-      };
-      sandbox = await VercelSandbox.create({ ...base, runtime, source });
-    } else {
-      sandbox = await VercelSandbox.create({ ...base, runtime });
-    }
+    const sandbox = await wrapVercelApiError("create sandbox", () => {
+      if (snapshotId) {
+        // Snapshot sources carry their own runtime; the Vercel SDK rejects
+        // `runtime` alongside a snapshot source, so we don't forward it here.
+        return VercelSandbox.create({
+          ...base,
+          source: { type: "snapshot", snapshotId },
+        });
+      }
+      if (provider?.gitSource) {
+        const git = provider.gitSource;
+        const source = {
+          type: "git" as const,
+          url: git.url,
+          depth: git.depth,
+          revision: git.revision,
+          ...(git.username && git.password
+            ? { username: git.username, password: git.password }
+            : {}),
+        };
+        return VercelSandbox.create({ ...base, runtime, source });
+      }
+      return VercelSandbox.create({ ...base, runtime });
+    });
 
     this.sandbox = sandbox;
     if (this.workingDir !== "/vercel/sandbox") {
-      await sandbox.runCommand({
-        cmd: "mkdir",
-        args: ["-p", this.workingDir],
-        sudo: true,
-      });
+      await wrapVercelApiError("create working directory", () =>
+        sandbox.runCommand({
+          cmd: "mkdir",
+          args: ["-p", this.workingDir],
+          sudo: true,
+        }),
+      );
     }
   }
 
@@ -178,12 +204,17 @@ export class VercelSandboxAdapter extends SandboxAdapter<
     await this.ensureProvisioned();
     const sandbox = this.requireSandbox();
 
-    const result = await sandbox.runCommand({
-      cmd: "sh",
-      args: ["-lc", toShellCommand(command)],
-      cwd: options?.cwd ?? this.workingDir,
-      env: this.getMergedEnv(options?.env),
-    });
+    const signal = buildTimeoutSignal(options?.timeoutMs);
+
+    const result = await wrapVercelApiError("run command", () =>
+      sandbox.runCommand({
+        cmd: "sh",
+        args: ["-lc", toShellCommand(command)],
+        cwd: options?.cwd ?? this.workingDir,
+        env: this.getMergedEnv(options?.env),
+        ...(signal ? { signal } : {}),
+      }),
+    );
 
     const [stdout, stderr] = await Promise.all([
       result.stdout(),
@@ -206,13 +237,18 @@ export class VercelSandboxAdapter extends SandboxAdapter<
     await this.ensureProvisioned();
     const sandbox = this.requireSandbox();
 
-    const cmd = await sandbox.runCommand({
-      cmd: "sh",
-      args: ["-lc", toShellCommand(command)],
-      cwd: options?.cwd ?? this.workingDir,
-      env: this.getMergedEnv(options?.env),
-      detached: true,
-    });
+    const signal = buildTimeoutSignal(options?.timeoutMs);
+
+    const cmd = await wrapVercelApiError("start async command", () =>
+      sandbox.runCommand({
+        cmd: "sh",
+        args: ["-lc", toShellCommand(command)],
+        cwd: options?.cwd ?? this.workingDir,
+        env: this.getMergedEnv(options?.env),
+        detached: true,
+        ...(signal ? { signal } : {}),
+      }),
+    );
 
     const queue = new AsyncQueue<CommandEvent>();
     let stdout = "";
@@ -271,44 +307,32 @@ export class VercelSandboxAdapter extends SandboxAdapter<
   }
 
   async list(options?: SandboxListOptions): Promise<SandboxDescriptor[]> {
-    const credentials = getCredentials(this.options);
     const filterTags = options?.tags ?? this.getTags();
-    let result;
-    try {
-      result = await VercelSandbox.list({
-        ...credentials,
-        tags: pickFirstTag(filterTags),
-      });
-    } catch (error) {
-      throw describeVercelApiError(error, "list sandboxes");
-    }
+    const sandboxes = await this.listSandboxesByTags(filterTags);
 
-    return result.sandboxes
-      .filter(
-        (s: { tags?: Record<string, string> }) =>
-          matchesAllTags(s.tags, filterTags),
-      )
-      .map(
-        (s: {
-          name: string;
-          status: string;
-          createdAt: number;
-          tags?: Record<string, string>;
-        }) => ({
-          provider: this.provider,
-          id: s.name,
-          state: s.status,
-          tags: s.tags ?? {},
-          createdAt: new Date(s.createdAt).toISOString(),
-          raw: s,
-        }),
-      );
+    return sandboxes.map(
+      (s: {
+        name: string;
+        status: string;
+        createdAt: number;
+        tags?: Record<string, string>;
+      }) => ({
+        provider: this.provider,
+        id: s.name,
+        state: s.status,
+        tags: s.tags ?? {},
+        createdAt: new Date(s.createdAt).toISOString(),
+        raw: s,
+      }),
+    );
   }
 
   async snapshot(): Promise<string | null> {
     await this.ensureProvisioned();
     const sandbox = this.requireSandbox();
-    const snap = await sandbox.snapshot();
+    const snap = await wrapVercelApiError("snapshot sandbox", () =>
+      sandbox.snapshot(),
+    );
     return snap.snapshotId;
   }
 
@@ -318,7 +342,7 @@ export class VercelSandboxAdapter extends SandboxAdapter<
       return;
     }
 
-    await sandbox.stop();
+    await wrapVercelApiError("stop sandbox", () => sandbox.stop());
     this.sandbox = undefined;
   }
 
@@ -366,29 +390,38 @@ export class VercelSandboxAdapter extends SandboxAdapter<
     };
   }
 
+  private async listSandboxesByTags(
+    tags: Record<string, string>,
+  ): Promise<
+    Array<{
+      name: string;
+      status: string;
+      createdAt: number;
+      tags?: Record<string, string>;
+    }>
+  > {
+    const credentials = getCredentials(this.options);
+    const result = await wrapVercelApiError("list sandboxes", () =>
+      VercelSandbox.list({
+        ...credentials,
+        tags: pickFirstTag(tags),
+      }),
+    );
+    return result.sandboxes.filter(
+      (s: { tags?: Record<string, string> }) => matchesAllTags(s.tags, tags),
+    );
+  }
+
   private async findExistingSandbox(): Promise<VercelSandbox | undefined> {
     const credentials = getCredentials(this.options);
-    const fullTags = this.getTags();
-    let result;
-    try {
-      result = await VercelSandbox.list({
-        ...credentials,
-        tags: pickFirstTag(fullTags),
-      });
-    } catch (error) {
-      throw describeVercelApiError(error, "list sandboxes");
-    }
-    const match = result.sandboxes.find(
-      (s: {
-        name: string;
-        status: string;
-        tags?: Record<string, string>;
-      }) => s.status === "running" && matchesAllTags(s.tags, fullTags),
-    );
+    const sandboxes = await this.listSandboxesByTags(this.getTags());
+    const match = sandboxes.find((s) => s.status === "running");
     if (!match) {
       return undefined;
     }
-    return VercelSandbox.get({ ...credentials, name: match.name });
+    return wrapVercelApiError("get sandbox", () =>
+      VercelSandbox.get({ ...credentials, name: match.name }),
+    );
   }
 
   private requireSandbox(): VercelSandbox {

--- a/src/sandboxes/providers/vercel.ts
+++ b/src/sandboxes/providers/vercel.ts
@@ -111,10 +111,6 @@ export class VercelSandboxAdapter extends SandboxAdapter<
 > {
   private sandbox?: VercelSandbox;
 
-  constructor(options: VercelSandboxOptions) {
-    super(options);
-  }
-
   get provider(): "vercel" {
     return "vercel";
   }

--- a/src/sandboxes/types.ts
+++ b/src/sandboxes/types.ts
@@ -1,4 +1,9 @@
-export type SandboxProviderName = "local-docker" | "modal" | "daytona" | "e2b";
+export type SandboxProviderName =
+  | "local-docker"
+  | "modal"
+  | "daytona"
+  | "vercel"
+  | "e2b";
 
 export interface CommandOptions {
   cwd?: string;
@@ -102,6 +107,37 @@ export interface DaytonaProviderOptions {
   public?: boolean;
 }
 
+export interface VercelGitSource {
+  url: string;
+  depth?: number;
+  revision?: string;
+  username?: string;
+  password?: string;
+}
+
+export interface VercelProviderOptions {
+  token?: string;
+  teamId?: string;
+  projectId?: string;
+  runtime?: string;
+  snapshotId?: string;
+  timeoutMs?: number;
+  gitSource?: VercelGitSource;
+  /**
+   * Ports to declare at sandbox creation time. The Vercel SDK requires ports
+   * to be known upfront; runtime-opened ports are not supported. Max 4.
+   */
+  ports?: number[];
+  /**
+   * Vercel Deployment Protection bypass token. When set, every request the
+   * agent transports send through the sandbox preview URL will include
+   * `x-vercel-protection-bypass: <token>`. Required when the linked Vercel
+   * project has Deployment Protection enabled — without it, POST requests
+   * to sandbox-exposed ports come back 200 + empty body.
+   */
+  protectionBypass?: string;
+}
+
 export interface E2bProviderOptions {
   apiKey?: string;
   accessToken?: string;
@@ -132,6 +168,10 @@ export interface DaytonaSandboxOptions extends SandboxOptionsBase {
   provider?: DaytonaProviderOptions;
 }
 
+export interface VercelSandboxOptions extends SandboxOptionsBase {
+  provider?: VercelProviderOptions;
+}
+
 export interface E2bSandboxOptions extends SandboxOptionsBase {
   provider?: E2bProviderOptions;
 }
@@ -140,6 +180,7 @@ export type SandboxOptionsMap = {
   "local-docker": LocalDockerSandboxOptions;
   modal: ModalSandboxOptions;
   daytona: DaytonaSandboxOptions;
+  vercel: VercelSandboxOptions;
   e2b: E2bSandboxOptions;
 };
 
@@ -151,6 +192,7 @@ export type SandboxRawMap = {
   "local-docker": import("./providers/local-docker").DockerRaw;
   modal: import("./providers/modal").ModalRaw;
   daytona: import("./providers/daytona").DaytonaRaw;
+  vercel: import("./providers/vercel").VercelRaw;
   e2b: import("./providers/e2b").E2bRaw;
 };
 

--- a/test/cli.e2e.test.ts
+++ b/test/cli.e2e.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const cli = ["npx", ["tsx", "src/cli.ts"]] as const;
+
+function exec(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return run(cli[0], [...cli[1], ...args], {
+    cwd: process.cwd(),
+    timeout: 10_000,
+    env: { ...process.env },
+  }).then(
+    ({ stdout, stderr }) => ({ stdout, stderr, exitCode: 0 }),
+    (error: { stdout?: string; stderr?: string; code?: number }) => ({
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+      exitCode: error.code ?? 1,
+    }),
+  );
+}
+
+describe("CLI E2E", () => {
+  // ── Help & usage ─────────────────────────────────────────────
+
+  it("prints help with no arguments (exit 0)", async () => {
+    const { stdout, exitCode } = await exec([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("agentbox");
+    expect(stdout).toContain("Usage:");
+  });
+
+  it("prints help with --help flag", async () => {
+    const { stdout, exitCode } = await exec(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  it("prints help with -h flag", async () => {
+    const { stdout, exitCode } = await exec(["-h"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  // ── Provider names in help ───────────────────────────────────
+
+  it("help text lists all five providers", async () => {
+    const { stdout } = await exec(["--help"]);
+    expect(stdout).toContain("local-docker");
+    expect(stdout).toContain("modal");
+    expect(stdout).toContain("daytona");
+    expect(stdout).toContain("vercel");
+    expect(stdout).toContain("e2b");
+  });
+
+  it("help text lists presets", async () => {
+    const { stdout } = await exec(["--help"]);
+    expect(stdout).toContain("browser-agent");
+    expect(stdout).toContain("computer-use");
+  });
+
+  it("help text documents Vercel env vars", async () => {
+    const { stdout } = await exec(["--help"]);
+    expect(stdout).toContain("VERCEL_TOKEN");
+    expect(stdout).toContain("VERCEL_TEAM_ID");
+    expect(stdout).toContain("VERCEL_PROJECT_ID");
+  });
+
+  // ── Invalid commands ─────────────────────────────────────────
+
+  it("rejects unknown commands with help + non-zero exit", async () => {
+    const { stdout, exitCode } = await exec(["bogus"]);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  it("rejects image build without --provider", async () => {
+    const { stdout, exitCode } = await exec([
+      "image",
+      "build",
+      "--preset",
+      "browser-agent",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  it("rejects image build without --preset or --file", async () => {
+    const { stdout, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+      "local-docker",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  // ── Provider validation ──────────────────────────────────────
+
+  it("accepts vercel as a valid provider name", async () => {
+    // vercel + preset triggers buildSandboxImage which will throw
+    // "Image building is not supported" — but that proves parsing worked.
+    const { stderr, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+      "vercel",
+      "--preset",
+      "browser-agent",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Image building is not supported");
+    expect(stderr).toContain("snapshots");
+  });
+
+  it("rejects unknown provider names", async () => {
+    const { stderr, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+      "aws",
+      "--preset",
+      "browser-agent",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Unsupported sandbox provider");
+  });
+
+  // ── Preset validation ────────────────────────────────────────
+
+  it("rejects unknown preset names", async () => {
+    const { stderr, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+      "local-docker",
+      "--preset",
+      "nonexistent",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Unknown built-in image preset");
+  });
+
+  // ── Option parsing ───────────────────────────────────────────
+
+  it("rejects unknown flags", async () => {
+    const { stderr, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+      "local-docker",
+      "--preset",
+      "browser-agent",
+      "--unknown-flag",
+      "value",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Unknown option");
+  });
+
+  it("rejects flags without values", async () => {
+    const { stderr, exitCode } = await exec([
+      "image",
+      "build",
+      "--provider",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Missing value");
+  });
+
+  // ── sandbox-image alias ──────────────────────────────────────
+
+  it("accepts sandbox-image as alias for image", async () => {
+    const { stderr, exitCode } = await exec([
+      "sandbox-image",
+      "build",
+      "--provider",
+      "vercel",
+      "--preset",
+      "browser-agent",
+    ]);
+    expect(exitCode).not.toBe(0);
+    // Should reach buildSandboxImage (not print help), proving alias works
+    expect(stderr).toContain("Image building is not supported");
+  });
+});

--- a/test/helpers/live-matrix-e2e.ts
+++ b/test/helpers/live-matrix-e2e.ts
@@ -14,7 +14,7 @@ import { buildSandboxImage } from "../../src/sandbox-images/build";
 
 export type LiveMatrixSandboxProvider = Extract<
   SandboxProviderName,
-  "local-docker" | "modal" | "daytona" | "e2b"
+  "local-docker" | "modal" | "daytona" | "e2b" | "vercel"
 >;
 
 export type LiveMatrixAgentProvider = AgentProviderName;
@@ -57,6 +57,7 @@ export const LIVE_MATRIX_SANDBOX_PROVIDERS = [
   "modal",
   "daytona",
   "e2b",
+  "vercel",
 ] as const satisfies readonly LiveMatrixSandboxProvider[];
 
 export const LIVE_MATRIX_AGENT_PROVIDERS = [
@@ -75,6 +76,9 @@ const OPENCODE_CONFIG_CONTENT = buildOpenCodeConfigContent();
 const LOCAL_DOCKER_OPENCODE_PORT = 4096;
 const MODAL_OPENCODE_PORT = 4096;
 const MODAL_CODEX_PORT = 43181;
+const VERCEL_OPENCODE_PORT = 4096;
+const VERCEL_CODEX_PORT = 43181;
+const VERCEL_CLAUDE_CODE_PORT = 43180;
 const IMAGE_BUILD_SUFFIX = randomUUID().slice(0, 8);
 const imageCache = new Map<LiveMatrixSandboxProvider, Promise<string>>();
 
@@ -146,82 +150,90 @@ export async function runSimpleStreamMatrixScenario(
   const sandbox = createSandboxForCombination(combination, image);
 
   try {
-    const version = await prepareSandboxForCombination(combination, sandbox);
-    const sessions = Array.from(
-      { length: LIVE_MATRIX_CONCURRENT_SESSION_COUNT },
-      (_, index) => {
-        const expectedText = `matrix-ok-${combination.sandboxProvider}-${combination.agentProvider}-${index + 1}-${randomUUID()}`;
-        const agent = createAgentForCombination(combination, sandbox);
-        const run = agent.stream({
-          input: `Reply with exactly ${expectedText} and nothing else.`,
-          model: getModelForCombination(combination.agentProvider),
-        });
-        void run.finished.catch(() => undefined);
-
-        return {
-          expectedText,
-          run,
-          eventTypes: [] as NormalizedAgentEvent["type"][],
-          streamedText: "",
-        };
-      },
-    );
-
-    const abortAllRuns = async () => {
-      await Promise.allSettled(sessions.map((session) => session.run.abort()));
-    };
-
-    await Promise.all(
-      sessions.map((session, index) =>
-        withTimeout(
-          `${formatLiveMatrixLabel(combination)} session ${index + 1}`,
-          () => session.run.sessionIdReady,
-          Math.min(LIVE_MATRIX_E2E_TIMEOUT_MS, 120_000),
-          () => session.run.abort(),
-        ),
-      ),
-    );
-
-    let completedSessions: LiveMatrixSessionResult[];
-    try {
-      completedSessions = await withTimeout(
-        `${formatLiveMatrixLabel(combination)} concurrent run`,
-        () =>
-          Promise.all(
-            sessions.map(async (session) => {
-              for await (const event of session.run) {
-                session.eventTypes.push(event.type);
-                if (event.type === "text.delta") {
-                  session.streamedText += event.delta;
-                }
-              }
-              const result = await session.run.finished;
-              return {
-                sessionId: result.sessionId,
-                expectedText: session.expectedText,
-                text: result.text.trim(),
-                streamedText: session.streamedText.trim(),
-                eventTypes: [...new Set(session.eventTypes)],
-              };
-            }),
-          ),
-        LIVE_MATRIX_E2E_TIMEOUT_MS,
-        abortAllRuns,
-      );
-    } catch (error) {
-      await abortAllRuns();
-      throw error;
-    }
-
-    return {
-      ...combination,
-      image,
-      version,
-      sessions: completedSessions,
-    };
+    return await runScenarioWithSandbox(combination, sandbox, image);
   } finally {
     await sandbox.delete().catch(() => undefined);
   }
+}
+
+async function runScenarioWithSandbox(
+  combination: LiveMatrixCombination,
+  sandbox: Sandbox<LiveMatrixSandboxProvider>,
+  image: string,
+): Promise<LiveMatrixScenarioResult> {
+  const version = await prepareSandboxForCombination(combination, sandbox);
+  const sessions = Array.from(
+    { length: LIVE_MATRIX_CONCURRENT_SESSION_COUNT },
+    (_, index) => {
+      const expectedText = `matrix-ok-${combination.sandboxProvider}-${combination.agentProvider}-${index + 1}-${randomUUID()}`;
+      const agent = createAgentForCombination(combination, sandbox);
+      const run = agent.stream({
+        input: `Reply with exactly ${expectedText} and nothing else.`,
+        model: getModelForCombination(combination.agentProvider),
+      });
+      void run.finished.catch(() => undefined);
+
+      return {
+        expectedText,
+        run,
+        eventTypes: [] as NormalizedAgentEvent["type"][],
+        streamedText: "",
+      };
+    },
+  );
+
+  const abortAllRuns = async () => {
+    await Promise.allSettled(sessions.map((session) => session.run.abort()));
+  };
+
+  await Promise.all(
+    sessions.map((session, index) =>
+      withTimeout(
+        `${formatLiveMatrixLabel(combination)} session ${index + 1}`,
+        () => session.run.sessionIdReady,
+        Math.min(LIVE_MATRIX_E2E_TIMEOUT_MS, 120_000),
+        () => session.run.abort(),
+      ),
+    ),
+  );
+
+  let completedSessions: LiveMatrixSessionResult[];
+  try {
+    completedSessions = await withTimeout(
+      `${formatLiveMatrixLabel(combination)} concurrent run`,
+      () =>
+        Promise.all(
+          sessions.map(async (session) => {
+            for await (const event of session.run) {
+              session.eventTypes.push(event.type);
+              if (event.type === "text.delta") {
+                session.streamedText += event.delta;
+              }
+            }
+            const result = await session.run.finished;
+            return {
+              sessionId: result.sessionId,
+              expectedText: session.expectedText,
+              text: result.text.trim(),
+              streamedText: session.streamedText.trim(),
+              eventTypes: [...new Set(session.eventTypes)],
+            };
+          }),
+        ),
+      LIVE_MATRIX_E2E_TIMEOUT_MS,
+      abortAllRuns,
+    );
+  } catch (error) {
+    await abortAllRuns();
+    throw error;
+  }
+
+  return {
+    ...combination,
+    image,
+    version,
+    sessions: completedSessions,
+  };
 }
 
 function buildLiveMatrixPlan(): {
@@ -267,6 +279,17 @@ function getSandboxSkipReason(
   if (sandboxProvider === "daytona") {
     if (!ROOT_ENV.DAYTONA_API_KEY && !ROOT_ENV.DAYTONA_JWT_TOKEN) {
       return "requires DAYTONA_API_KEY or DAYTONA_JWT_TOKEN.";
+    }
+    return null;
+  }
+
+  if (sandboxProvider === "vercel") {
+    if (
+      !ROOT_ENV.VERCEL_TOKEN ||
+      !ROOT_ENV.VERCEL_TEAM_ID ||
+      !ROOT_ENV.VERCEL_PROJECT_ID
+    ) {
+      return "requires VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID.";
     }
     return null;
   }
@@ -361,6 +384,13 @@ async function resolveSandboxImage(
       });
     }
 
+    if (sandboxProvider === "vercel") {
+      if (ROOT_ENV.AGENTBOX_VERCEL_SNAPSHOT_ID) {
+        return ROOT_ENV.AGENTBOX_VERCEL_SNAPSHOT_ID;
+      }
+      return buildVercelMatrixSnapshot();
+    }
+
     return buildSandboxImage({
       provider: "e2b",
       preset: "browser-agent",
@@ -446,6 +476,37 @@ function createSandboxForCombination(
           ? { apiUrl: ROOT_ENV.DAYTONA_API_URL }
           : {}),
         ...(ROOT_ENV.DAYTONA_TARGET ? { target: ROOT_ENV.DAYTONA_TARGET } : {}),
+      },
+    });
+  }
+
+  if (combination.sandboxProvider === "vercel") {
+    // Vercel sandboxes are capped at 5 tags total. The shared `tags` block
+    // already has 5 entries, and the adapter auto-adds `agentbox.provider`,
+    // which would push us to 6 and fail at create time. Drop `runner` since
+    // `scope: "e2e"` already conveys it.
+    const { runner: _runner, ...vercelTags } = tags;
+    void _runner;
+    return new Sandbox("vercel", {
+      workingDir: "/workspace",
+      tags: vercelTags,
+      resources: {
+        cpu: 2,
+        memoryMiB: 4096,
+      },
+      provider: {
+        runtime: "node24",
+        snapshotId: image,
+        timeoutMs: 30 * 60_000,
+        ports: getVercelPortsForAgent(combination.agentProvider),
+        ...(ROOT_ENV.VERCEL_TOKEN ? { token: ROOT_ENV.VERCEL_TOKEN } : {}),
+        ...(ROOT_ENV.VERCEL_TEAM_ID ? { teamId: ROOT_ENV.VERCEL_TEAM_ID } : {}),
+        ...(ROOT_ENV.VERCEL_PROJECT_ID
+          ? { projectId: ROOT_ENV.VERCEL_PROJECT_ID }
+          : {}),
+        ...(ROOT_ENV.VERCEL_PROTECTION_BYPASS
+          ? { protectionBypass: ROOT_ENV.VERCEL_PROTECTION_BYPASS }
+          : {}),
       },
     });
   }
@@ -600,6 +661,81 @@ function getModalPortsForAgent(
   }
 
   return [43180];
+}
+
+function getVercelPortsForAgent(
+  agentProvider: LiveMatrixAgentProvider,
+): number[] {
+  if (agentProvider === "codex") {
+    return [VERCEL_CODEX_PORT];
+  }
+
+  if (agentProvider === "opencode") {
+    return [VERCEL_OPENCODE_PORT];
+  }
+
+  // claude-code uses an SDK WebSocket relay on REMOTE_SDK_RELAY_PORT (43180)
+  return [VERCEL_CLAUDE_CODE_PORT];
+}
+
+async function buildVercelMatrixSnapshot(): Promise<string> {
+  if (
+    !ROOT_ENV.VERCEL_TOKEN ||
+    !ROOT_ENV.VERCEL_TEAM_ID ||
+    !ROOT_ENV.VERCEL_PROJECT_ID
+  ) {
+    throw new Error(
+      "Vercel matrix snapshot build requires VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID.",
+    );
+  }
+
+  const log = (chunk: string) => logImageBuildProgress("vercel", chunk);
+
+  const prep = new Sandbox("vercel", {
+    workingDir: "/workspace",
+    tags: {
+      scope: "e2e",
+      runner: "live-matrix",
+      role: "snapshot-build",
+      run: IMAGE_BUILD_SUFFIX,
+    },
+    resources: { cpu: 2, memoryMiB: 4096 },
+    provider: {
+      runtime: "node24",
+      timeoutMs: 30 * 60_000,
+      token: ROOT_ENV.VERCEL_TOKEN,
+      teamId: ROOT_ENV.VERCEL_TEAM_ID,
+      projectId: ROOT_ENV.VERCEL_PROJECT_ID,
+      ...(ROOT_ENV.VERCEL_PROTECTION_BYPASS
+        ? { protectionBypass: ROOT_ENV.VERCEL_PROTECTION_BYPASS }
+        : {}),
+    },
+  });
+
+  try {
+    log("provisioning prep sandbox");
+    const install = await prep.run(
+      "sudo npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai",
+      { timeoutMs: 5 * 60_000 },
+    );
+    if (install.exitCode !== 0) {
+      throw new Error(
+        `Failed to install agent CLIs in Vercel prep sandbox: ${
+          install.stderr || install.combinedOutput
+        }`,
+      );
+    }
+    log("agent CLIs installed");
+
+    const snapshotId = await prep.snapshot();
+    if (!snapshotId) {
+      throw new Error("Vercel prep sandbox returned a null snapshot id.");
+    }
+    log(`snapshot ready ${snapshotId}`);
+    return snapshotId;
+  } finally {
+    await prep.delete().catch(() => undefined);
+  }
 }
 
 function buildOpenCodeConfigContent(): string | undefined {

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -51,6 +51,27 @@ describe.skipIf(!smokeEnabled)("optional provider smoke tests", () => {
     expect(Array.isArray(sandboxes)).toBe(true);
   });
 
+  it("can list Vercel sandboxes when credentials are present", async () => {
+    if (
+      !process.env.VERCEL_TOKEN ||
+      !process.env.VERCEL_TEAM_ID ||
+      !process.env.VERCEL_PROJECT_ID
+    ) {
+      return;
+    }
+
+    const sandbox = new Sandbox("vercel", {
+      provider: {
+        token: process.env.VERCEL_TOKEN,
+        teamId: process.env.VERCEL_TEAM_ID,
+        projectId: process.env.VERCEL_PROJECT_ID,
+      },
+    });
+
+    const sandboxes = await sandbox.list();
+    expect(Array.isArray(sandboxes)).toBe(true);
+  });
+
   it("can list E2B sandboxes when credentials are present", async () => {
     if (!process.env.E2B_API_KEY) {
       return;

--- a/test/vercel-integration.e2e.test.ts
+++ b/test/vercel-integration.e2e.test.ts
@@ -220,9 +220,11 @@ describe.skipIf(!enabled)("Vercel Sandbox E2E", () => {
     await expect(sandbox.openPort(3000)).resolves.toBe(sandbox);
   });
 
-  it("getPreviewLink: returns a URL for a declared port", async () => {
-    // Vercel sandboxes require ports declared at creation time.
-    // Create a dedicated sandbox with port 8080 exposed.
+  it("getPreviewLink: throws for ports not declared at create time", async () => {
+    // Vercel sandboxes require ports to be declared at creation time via
+    // `provider.ports`. This sandbox intentionally omits `provider.ports`,
+    // so port 8080 is never registered with the SDK — we expect
+    // `getPreviewLink(8080)` to throw.
     const portSandbox = new Sandbox("vercel", {
       tags: { suite: "e2e-port" },
       provider: {
@@ -232,14 +234,10 @@ describe.skipIf(!enabled)("Vercel Sandbox E2E", () => {
       },
     });
 
-    // Provision by running a command — this triggers Sandbox.create
-    // but we need ports declared. The SDK accepts ports in create().
-    // Since our adapter doesn't expose ports in create, we test that
-    // domain() throws for undeclared ports (expected behavior).
+    // Force provisioning via a no-op command.
     const r = await portSandbox.run("echo ok");
     expect(r.exitCode).toBe(0);
 
-    // Undeclared ports should throw
     await expect(portSandbox.getPreviewLink(8080)).rejects.toThrow();
 
     await portSandbox.stop();

--- a/test/vercel-integration.e2e.test.ts
+++ b/test/vercel-integration.e2e.test.ts
@@ -216,8 +216,12 @@ describe.skipIf(!enabled)("Vercel Sandbox E2E", () => {
 
   // ── openPort / getPreviewLink ────────────────────────────────
 
-  it("openPort: is a no-op (does not throw)", async () => {
+  it("openPort: is a no-op and does not actually register the port", async () => {
+    // Vercel ports must be declared at create time via `provider.ports`.
+    // `openPort()` is accepted for API parity but cannot retroactively
+    // register a port with the SDK — `getPreviewLink` should still throw.
     await expect(sandbox.openPort(3000)).resolves.toBe(sandbox);
+    await expect(sandbox.getPreviewLink(3000)).rejects.toThrow();
   });
 
   it("getPreviewLink: throws for ports not declared at create time", async () => {

--- a/test/vercel-integration.e2e.test.ts
+++ b/test/vercel-integration.e2e.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { Sandbox } from "../src";
+
+const creds = {
+  token: process.env.VERCEL_TOKEN,
+  teamId: process.env.VERCEL_TEAM_ID,
+  projectId: process.env.VERCEL_PROJECT_ID,
+};
+
+const enabled =
+  process.env.AGENTBOX_RUN_VERCEL_E2E === "1" &&
+  !!creds.token &&
+  !!creds.teamId &&
+  !!creds.projectId;
+
+describe.skipIf(!enabled)("Vercel Sandbox E2E", () => {
+  let sandbox: Sandbox<"vercel">;
+
+  beforeAll(() => {
+    sandbox = new Sandbox("vercel", {
+      tags: { suite: "e2e" },
+      provider: {
+        runtime: "node24",
+        timeoutMs: 120_000,
+        ...creds,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await sandbox.stop();
+  });
+
+  // ── Provisioning & Identity ──────────────────────────────────
+
+  it("provisions a sandbox and exposes an id", async () => {
+    const result = await sandbox.run("echo hello");
+    expect(result.exitCode).toBe(0);
+    expect(sandbox.id).toBeDefined();
+    expect(typeof sandbox.id).toBe("string");
+  }, 30_000);
+
+  it("exposes provider name", () => {
+    expect(sandbox.provider).toBe("vercel");
+  });
+
+  it("exposes raw Vercel sandbox object", async () => {
+    // Ensure provisioned first
+    await sandbox.run("true");
+    const raw = sandbox.raw as { sandbox?: unknown };
+    expect(raw.sandbox).toBeDefined();
+  });
+
+  it("defaults workingDir to /vercel/sandbox", async () => {
+    const result = await sandbox.run("pwd");
+    expect(result.stdout.trim()).toBe("/vercel/sandbox");
+  });
+
+  // ── run() ────────────────────────────────────────────────────
+
+  it("run: returns stdout, stderr, exitCode", async () => {
+    const result = await sandbox.run("echo out && echo err >&2");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("out");
+    expect(result.stderr).toContain("err");
+    expect(result.combinedOutput).toContain("out");
+    expect(result.combinedOutput).toContain("err");
+  });
+
+  it("run: returns non-zero exit code on failure", async () => {
+    const result = await sandbox.run("exit 42");
+    expect(result.exitCode).toBe(42);
+  });
+
+  it("run: accepts command as array", async () => {
+    const result = await sandbox.run(["echo", "array", "args"]);
+    expect(result.stdout).toContain("array args");
+  });
+
+  it("run: respects custom cwd", async () => {
+    const result = await sandbox.run("pwd", { cwd: "/tmp" });
+    expect(result.stdout.trim()).toBe("/tmp");
+  });
+
+  it("run: passes custom env vars", async () => {
+    const result = await sandbox.run("echo $MY_VAR", {
+      env: { MY_VAR: "hello_from_env" },
+    });
+    expect(result.stdout).toContain("hello_from_env");
+  });
+
+  // ── setSecret / setSecrets ───────────────────────────────────
+
+  it("setSecret: injects secret into subsequent commands", async () => {
+    sandbox.setSecret("SECRET_KEY", "s3cr3t_value");
+    const result = await sandbox.run("echo $SECRET_KEY");
+    expect(result.stdout).toContain("s3cr3t_value");
+  });
+
+  it("setSecrets: injects multiple secrets", async () => {
+    sandbox.setSecrets({ A: "alpha", B: "bravo" });
+    const result = await sandbox.run("echo $A $B");
+    expect(result.stdout).toContain("alpha bravo");
+  });
+
+  // ── runAsync() ───────────────────────────────────────────────
+
+  it("runAsync: streams stdout events and resolves via wait()", async () => {
+    const handle = await sandbox.runAsync(
+      "for i in 1 2 3; do echo line$i; sleep 0.1; done",
+    );
+
+    const chunks: string[] = [];
+    for await (const event of handle) {
+      if (event.type === "stdout" && event.chunk) {
+        chunks.push(event.chunk);
+      }
+      if (event.type === "exit") {
+        expect(event.exitCode).toBe(0);
+      }
+    }
+
+    expect(chunks.join("")).toContain("line1");
+    expect(chunks.join("")).toContain("line2");
+    expect(chunks.join("")).toContain("line3");
+
+    const result = await handle.wait();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("line1");
+  });
+
+  it("runAsync: kill terminates the command", async () => {
+    const handle = await sandbox.runAsync("sleep 60");
+    await handle.kill();
+    const result = await handle.wait();
+    // Killed commands return non-zero
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  // ── gitClone() ───────────────────────────────────────────────
+
+  it("gitClone: clones a public repo", async () => {
+    const result = await sandbox.gitClone({
+      repoUrl: "https://github.com/octocat/Hello-World.git",
+      targetDir: "/vercel/sandbox/hello-world",
+      depth: 1,
+    });
+    expect(result.exitCode).toBe(0);
+
+    const ls = await sandbox.run("ls /vercel/sandbox/hello-world/README");
+    expect(ls.exitCode).toBe(0);
+  });
+
+  // ── uploadFile / downloadFile ────────────────────────────────
+
+  it("uploadFile: writes a string file", async () => {
+    await sandbox.uploadFile(
+      "hello world\n",
+      "/vercel/sandbox/test-upload.txt",
+    );
+
+    const result = await sandbox.run("cat /vercel/sandbox/test-upload.txt");
+    expect(result.stdout).toContain("hello world");
+  });
+
+  it("uploadFile: writes a Buffer file", async () => {
+    await sandbox.uploadFile(
+      Buffer.from("binary content"),
+      "/vercel/sandbox/test-binary.txt",
+    );
+
+    const result = await sandbox.run("cat /vercel/sandbox/test-binary.txt");
+    expect(result.stdout).toContain("binary content");
+  });
+
+  it("downloadFile: reads back a file", async () => {
+    await sandbox.run("echo download-test > /vercel/sandbox/dl-test.txt");
+
+    const buffer = await sandbox.downloadFile("/vercel/sandbox/dl-test.txt");
+    expect(buffer.toString("utf8")).toContain("download-test");
+  });
+
+  it("downloadFile: throws on missing file", async () => {
+    await expect(
+      sandbox.downloadFile("/vercel/sandbox/does-not-exist.txt"),
+    ).rejects.toThrow();
+  });
+
+  // ── list() ───────────────────────────────────────────────────
+
+  it("list: returns sandboxes with agentbox.provider tag", async () => {
+    const sandboxes = await sandbox.list();
+    expect(Array.isArray(sandboxes)).toBe(true);
+    expect(sandboxes.length).toBeGreaterThan(0);
+
+    const current = sandboxes.find((s) => s.id === sandbox.id);
+    expect(current).toBeDefined();
+    expect(current?.state).toBe("running");
+    expect(current?.tags["agentbox.provider"]).toBe("vercel");
+  });
+
+  it("list: filters by custom tags", async () => {
+    const filtered = await sandbox.list({ tags: { suite: "e2e" } });
+    expect(filtered.length).toBeGreaterThan(0);
+    for (const s of filtered) {
+      expect(s.tags["suite"]).toBe("e2e");
+    }
+  });
+
+  it("list: returns empty for non-matching tags", async () => {
+    const filtered = await sandbox.list({
+      tags: { nonexistent: "tag" },
+    });
+    expect(filtered).toEqual([]);
+  });
+
+  // ── openPort / getPreviewLink ────────────────────────────────
+
+  it("openPort: is a no-op (does not throw)", async () => {
+    await expect(sandbox.openPort(3000)).resolves.toBe(sandbox);
+  });
+
+  it("getPreviewLink: returns a URL for a declared port", async () => {
+    // Vercel sandboxes require ports declared at creation time.
+    // Create a dedicated sandbox with port 8080 exposed.
+    const portSandbox = new Sandbox("vercel", {
+      tags: { suite: "e2e-port" },
+      provider: {
+        runtime: "node24",
+        timeoutMs: 60_000,
+        ...creds,
+      },
+    });
+
+    // Provision by running a command — this triggers Sandbox.create
+    // but we need ports declared. The SDK accepts ports in create().
+    // Since our adapter doesn't expose ports in create, we test that
+    // domain() throws for undeclared ports (expected behavior).
+    const r = await portSandbox.run("echo ok");
+    expect(r.exitCode).toBe(0);
+
+    // Undeclared ports should throw
+    await expect(portSandbox.getPreviewLink(8080)).rejects.toThrow();
+
+    await portSandbox.stop();
+  }, 30_000);
+
+  // ── Node.js runtime ──────────────────────────────────────────
+
+  it("runtime: node24 is available", async () => {
+    const result = await sandbox.run("node --version");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^v2[4-9]/);
+  }, 15_000);
+
+  it("runtime: npm is available", async () => {
+    const result = await sandbox.run("npm --version");
+    expect(result.exitCode).toBe(0);
+  }, 15_000);
+
+  // ── stop() ───────────────────────────────────────────────────
+
+  it("stop: terminates the sandbox", async () => {
+    // Create a separate sandbox for stop test
+    const tempSandbox = new Sandbox("vercel", {
+      tags: { suite: "e2e-stop" },
+      provider: {
+        runtime: "node24",
+        timeoutMs: 60_000,
+        ...creds,
+      },
+    });
+
+    // Provision it
+    const r = await tempSandbox.run("echo alive");
+    expect(r.exitCode).toBe(0);
+    const tempId = tempSandbox.id;
+    expect(tempId).toBeDefined();
+
+    // Stop it
+    await tempSandbox.stop();
+
+    // Id should be cleared
+    expect(tempSandbox.id).toBeUndefined();
+  }, 30_000);
+});


### PR DESCRIPTION
Adds `vercel` as a fifth sandbox provider, built on `@vercel/sandbox` v2 beta, integrated into the live agent × sandbox matrix alongside `local-docker`, `modal`, `daytona`, and `e2b`.

## What's in

**Core provider** — `src/sandboxes/providers/vercel.ts`
- Full `SandboxAdapter` implementation: `provision`, `run`, `runAsync` (streaming logs), `gitClone`, `list`, `snapshot`, `stop`, `delete`, `openPort`, `getPreviewLink`, `uploadFile`, `downloadFile`
- Tag-based reuse via `agentbox.provider` + caller tags, matching peer provider conventions
- Three provisioning sources: default runtime, native git source (with optional basic auth), and `snapshotId` resume — the `runtime` field is dropped on snapshot sources since Vercel infers it
- Default `workingDir` is `/vercel/sandbox` (Vercel platform constraint); custom working dirs are `mkdir -p`'d with `sudo` during provisioning
- `SandboxRawMap` updated so `sandbox.raw` is typed as `VercelRaw`
- Respects Vercel's per-call API limits: `list()` sends only a single tag filter server-side ("only one tag filter at a time") and intersects the rest client-side; matrix tags sized so the total including the auto-added `agentbox.provider` stays ≤ 5 (the Vercel cap)
- `VercelProviderOptions.ports` — declare ports at create time (SDK requires ports known upfront)
- `VercelProviderOptions.protectionBypass` — optional Deployment Protection bypass token; flows through a new `Sandbox.previewHeaders` getter that every agent transport (opencode, claude-code, codex) merges into HTTP and WebSocket requests against the preview URL

**Shared base + facade plumbing** — `src/sandboxes/base.ts`, `src/sandboxes/Sandbox.ts`
- New `previewHeaders` getter on `SandboxAdapter` (default `{}`), exposed on the `Sandbox` facade, used by every agent transport to inject provider-specific headers
- Default `uploadFile` / `downloadFile` methods on the base that throw `"not supported"`, exposed on the `Sandbox` facade — `local-docker` and `vercel` override them

**Agent transport threading** — `src/agents/transports/{app-server,sdk-ws}.ts`, `src/agents/providers/{opencode,claude-code,codex}.ts`
- `previewHeaders` threads cleanly through `fetchJson`, `streamSse`, `SharedSdkWsConnection`, and `connectJsonRpcWebSocket`
- Opencode's `ensureSandboxOpenCodeServer` now polls `/global/health` via in-sandbox curl instead of via the preview URL — see the **Opencode readiness fix** section below

**CLI & image builder** — `src/cli.ts`, `src/sandbox-images/build.ts`
- `--provider vercel` accepted and documented in CLI help
- `buildSandboxImage` throws with a pointer to `Sandbox.snapshot()` for Vercel — it uses runtime snapshots rather than prebuilt images
- CLI help lists the three required `VERCEL_*` env vars

**Example** — `examples/basic-vercel.ts`
- Standalone script matching the repo's simple example style

**Tests**
- `test/vercel-integration.e2e.test.ts` — 26-test adapter-level e2e suite (provision, identity, run/runAsync, secrets, gitClone, uploadFile/downloadFile, list filtering, openPort/getPreviewLink, runtime checks, stop). Gated on `AGENTBOX_RUN_VERCEL_E2E` + `VERCEL_*` creds; intended for local debugging, not CI
- `test/smoke.test.ts` — adds a Vercel list smoke check under the existing opt-in
- `test/cli.e2e.test.ts` — asserts Vercel is listed in help and accepted as a provider

**Live matrix integration** — `test/helpers/live-matrix-e2e.ts`
- `vercel` joins `LIVE_MATRIX_SANDBOX_PROVIDERS` — three new combinations: `vercel × codex`, `vercel × opencode`, `vercel × claude-code`
- `resolveSandboxImage` builds a snapshot for Vercel by provisioning a fresh sandbox, npm-installing the agent CLIs, and calling `sandbox.snapshot()`. Honors `AGENTBOX_VERCEL_SNAPSHOT_ID` as an override matching the existing `AGENTBOX_MODAL_IMAGE` / `AGENTBOX_E2B_DOCKER_IMAGE` pattern
- `createSandboxForCombination` creates Vercel sandboxes from the snapshot with the right ports per agent, resources, tags, and optional `protectionBypass`

**CI** — `.github/workflows/e2e.yml`
- The existing live-matrix workflow job gains `VERCEL_TOKEN` / `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` / `VERCEL_PROTECTION_BYPASS` secrets
- No separate workflow job; vercel is a first-class member of the single live-matrix run

**Dependencies**
- `@vercel/sandbox` pinned to `2.0.0-beta.13` exactly until v2 stabilizes

## Opencode readiness fix (non-obvious, worth reading)

`ensureSandboxOpenCodeServer` used to wait for opencode to be ready by calling `waitForHttpReady(${previewUrl}/global/health)` through the Vercel sandbox preview URL. Vercel's sandbox edge proxy returns a **synthetic `200 OK, Content-Length: 0`** for requests to sandbox ports that don't yet have an active listener, which `waitForHttpReady` happily treated as "ready". That raced opencode's first-run DB migration (`Performing one time database migration, may take a few minutes...`): the adapter proceeded to `POST /session` while opencode was still migrating, the proxy returned the same synthetic empty 200, and the matrix test failed with `"200 with an empty body"`.

**Fix**: poll readiness via `sandbox.run("curl -fsS http://127.0.0.1:${port}/global/health")` from **inside** the sandbox. Inside curl gets a kernel-level `ECONNREFUSED` during migration, with no proxy synthesis, so we actually wait until opencode is accepting connections.

Other providers weren't affected because their sandbox proxies don't return synthetic 200s for dead ports. `vercel × codex` and `vercel × claude-code` weren't affected because their transports are WebSocket-based — a WS upgrade to a dead port fails cleanly.

## Behavior differences vs other providers (by design)

- **`workingDir`** defaults to `/vercel/sandbox` instead of `/workspace` — Vercel platform constraint. Custom dirs are `mkdir -p`'d with `sudo` during provisioning.
- **No image build** path — Vercel uses runtime snapshots. Use `sandbox.snapshot()` and pass the result via `provider.snapshotId`.
- **`openPort` is a no-op at runtime** — Vercel ports must be declared at create time via `provider.ports`; there's no runtime equivalent.

## Matrix result

```
✓ vercel × codex       ~35 s
✓ vercel × opencode    ~13 s
✓ vercel × claude-code ~12 s
```

All three combos pass with `LIVE_MATRIX_CONCURRENT_SESSION_COUNT = 2` (the default).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (57 pass / 46 opt-in skipped)
- [x] Live matrix: `AGENTBOX_RUN_MATRIX_E2E=1 VERCEL_TOKEN=… VERCEL_TEAM_ID=… VERCEL_PROJECT_ID=… ANTHROPIC_API_KEY=… OPENAI_API_KEY=… MODAL_TOKEN_ID=… MODAL_TOKEN_SECRET=… npm run test:e2e:matrix` — all three `vercel × *` combos pass
- [ ] CI: live-matrix workflow run against the configured secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)