### PR TITLE
fix(opencode): cap server output token reserve at 16k

### DIFF
--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -70,6 +70,17 @@ const SANDBOX_OPENCODE_READY_TIMEOUT_MS = 90_000;
 const LOCAL_OPENCODE_READY_TIMEOUT_MS = 20_000;
 const SHARED_OPENCODE_TARGET_ID = "shared-opencode-server";
 
+// opencode hardcodes `OUTPUT_TOKEN_MAX = 32_000` in
+// `packages/opencode/src/provider/transform.ts` and reserves it as
+// `max_tokens` on every chat-completion request. On a 200K-context model
+// (e.g. Claude Sonnet 4.5 via OpenRouter) that 32K reserve eats into the
+// usable input budget hard — runs with ~180K of input would overflow
+// (`input + 32000 > 204800`). The only override opencode exposes is the
+// `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` env var, applied at the
+// `opencode serve` process level. 16000 keeps responses comfortably long
+// while giving back ~16K of input headroom.
+const OPENCODE_OUTPUT_TOKEN_MAX = "16000";
+
 function toRawEvent(
   runId: string,
   payload: unknown,
@@ -334,6 +345,7 @@ async function ensureSandboxOpenCodeServer(
       OPENCODE_CONFIG: configPath,
       OPENCODE_CONFIG_DIR: target.layout.opencodeDir,
       OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+      OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX: OPENCODE_OUTPUT_TOKEN_MAX,
     };
 
     await applyDifferentialSetup(target, allArtifacts, installCommands);
@@ -498,6 +510,7 @@ async function ensureLocalOpenCodeServer(
     OPENCODE_CONFIG: configPath,
     OPENCODE_CONFIG_DIR: target.layout.opencodeDir,
     OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+    OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX: OPENCODE_OUTPUT_TOKEN_MAX,
   };
 
   const allArtifacts = [


### PR DESCRIPTION
## Summary
- opencode hardcodes a 32K \`max_tokens\` reserve (\`OUTPUT_TOKEN_MAX\` in \`packages/opencode/src/provider/transform.ts\`) on every chat-completion request, leaving only ~172K of input on a 200K-context model.
- Real runs overflow on the OpenRouter side: \`This endpoint's maximum context length is 204800 tokens. However, you requested about 211116 tokens (163939 of text input, 15177 of tool input, 32000 in the output).\`
- The only knob opencode exposes is the \`OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX\` env var, applied at the \`opencode serve\` process level. Set it to \`16000\` in both the sandbox and local spawn paths to claw back ~16K of input headroom; responses can still run long.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [ ] Trigger an opencode run that previously hit \`204800\` token overflow on OpenRouter and confirm it completes
- [ ] Confirm normal-sized runs still produce full-length responses (no truncation visible)