### PR TITLE
feat(opencode): forward OpenRouter plugins through agent options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentbox-sdk",
-  "version": "0.1.315",
+  "version": "0.1.316",
   "description": "Swappable coding agents and sandbox providers for Bun and TypeScript.",
   "license": "MIT",
   "repository": {

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -239,6 +239,10 @@ export function buildOpenCodeConfig(
   );
   const googleBaseUrl = options.env?.GOOGLE_BASE_URL;
   const openRouterBaseUrl = options.env?.OPENROUTER_BASE_URL;
+  const openRouterPlugins =
+    options.openRouterPlugins && options.openRouterPlugins.length > 0
+      ? options.openRouterPlugins
+      : undefined;
 
   return {
     $schema: "https://opencode.ai/config.json",
@@ -248,6 +252,10 @@ export function buildOpenCodeConfig(
       openrouter: {
         options: {
           baseURL: openRouterBaseUrl || "https://openrouter.ai/api/v1",
+          // The OpenRouter AI SDK spreads `providerOptions.openrouter`
+          // keys into the chat-completion request body verbatim, so
+          // `plugins` here ends up on every outbound request.
+          ...(openRouterPlugins ? { plugins: openRouterPlugins } : {}),
         },
       },
       ...(googleBaseUrl

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -252,9 +252,6 @@ export function buildOpenCodeConfig(
       openrouter: {
         options: {
           baseURL: openRouterBaseUrl || "https://openrouter.ai/api/v1",
-          // The OpenRouter AI SDK spreads `providerOptions.openrouter`
-          // keys into the chat-completion request body verbatim, so
-          // `plugins` here ends up on every outbound request.
           ...(openRouterPlugins ? { plugins: openRouterPlugins } : {}),
         },
       },

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -170,8 +170,41 @@ export interface CodexAgentOptions extends AgentOptionsBase {
   provider?: CodexProviderOptions;
 }
 
+/**
+ * Shape of a single OpenRouter plugin entry. The OpenRouter AI SDK spreads
+ * `providerOptions.openrouter` keys into the chat-completion request body
+ * verbatim, so anything in this array is forwarded as-is to OpenRouter.
+ *
+ * The canonical example is the context-compression plugin:
+ *
+ *     { id: "context-compression" }
+ *
+ * which enables OpenRouter's middle-out message compression — useful when
+ * runs routinely overflow a model's context window. Disable an
+ * account-wide default with `{ id: "context-compression", enabled: false }`.
+ *
+ * See https://openrouter.ai/docs/guides/features/message-transforms.
+ */
+export interface OpenRouterPlugin {
+  id: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
 export interface OpenCodeAgentOptions extends AgentOptionsBase {
   provider?: OpenCodeProviderOptions;
+  /**
+   * OpenRouter plugins to attach to every chat-completion request made by
+   * the opencode server. Forwarded into the `openrouter` provider options
+   * block of `agentbox.json`; the OpenRouter AI SDK spreads them into the
+   * request body. Most common use: enable context-compression on
+   * 200K-context models to avoid overflow when input + opencode's hardcoded
+   * 32K output reserve exceeds the model's window.
+   *
+   * Setup-time field: changes invalidate the setup-manifest cache and
+   * re-upload `agentbox.json` on the next `setup()` call.
+   */
+  openRouterPlugins?: OpenRouterPlugin[];
   /**
    * Setup-time system prompt baked into the opencode agent's `prompt` field.
    *

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -170,21 +170,6 @@ export interface CodexAgentOptions extends AgentOptionsBase {
   provider?: CodexProviderOptions;
 }
 
-/**
- * Shape of a single OpenRouter plugin entry. The OpenRouter AI SDK spreads
- * `providerOptions.openrouter` keys into the chat-completion request body
- * verbatim, so anything in this array is forwarded as-is to OpenRouter.
- *
- * The canonical example is the context-compression plugin:
- *
- *     { id: "context-compression" }
- *
- * which enables OpenRouter's middle-out message compression — useful when
- * runs routinely overflow a model's context window. Disable an
- * account-wide default with `{ id: "context-compression", enabled: false }`.
- *
- * See https://openrouter.ai/docs/guides/features/message-transforms.
- */
 export interface OpenRouterPlugin {
   id: string;
   enabled?: boolean;
@@ -193,17 +178,6 @@ export interface OpenRouterPlugin {
 
 export interface OpenCodeAgentOptions extends AgentOptionsBase {
   provider?: OpenCodeProviderOptions;
-  /**
-   * OpenRouter plugins to attach to every chat-completion request made by
-   * the opencode server. Forwarded into the `openrouter` provider options
-   * block of `agentbox.json`; the OpenRouter AI SDK spreads them into the
-   * request body. Most common use: enable context-compression on
-   * 200K-context models to avoid overflow when input + opencode's hardcoded
-   * 32K output reserve exceeds the model's window.
-   *
-   * Setup-time field: changes invalidate the setup-manifest cache and
-   * re-upload `agentbox.json` on the next `setup()` call.
-   */
   openRouterPlugins?: OpenRouterPlugin[];
   /**
    * Setup-time system prompt baked into the opencode agent's `prompt` field.

--- a/test/agent-reasoning.test.ts
+++ b/test/agent-reasoning.test.ts
@@ -125,3 +125,43 @@ describe("reasoning param", () => {
     });
   });
 });
+
+describe("buildOpenCodeConfig openRouterPlugins", () => {
+  it("omits plugins when openRouterPlugins is unset", () => {
+    const config = buildOpenCodeConfig(
+      makeOpenCodeRequest().options,
+      false,
+    ) as {
+      provider: {
+        openrouter: { options: { baseURL: string; plugins?: unknown } };
+      };
+    };
+    expect(config.provider.openrouter.options.plugins).toBeUndefined();
+  });
+
+  it("forwards openRouterPlugins into the openrouter options block", () => {
+    const request = makeOpenCodeRequest();
+    request.options.openRouterPlugins = [{ id: "context-compression" }];
+    const config = buildOpenCodeConfig(request.options, false) as {
+      provider: {
+        openrouter: {
+          options: { plugins: Array<{ id: string }> };
+        };
+      };
+    };
+    expect(config.provider.openrouter.options.plugins).toEqual([
+      { id: "context-compression" },
+    ]);
+  });
+
+  it("omits plugins when openRouterPlugins is an empty array", () => {
+    const request = makeOpenCodeRequest();
+    request.options.openRouterPlugins = [];
+    const config = buildOpenCodeConfig(request.options, false) as {
+      provider: {
+        openrouter: { options: { plugins?: unknown } };
+      };
+    };
+    expect(config.provider.openrouter.options.plugins).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add \`OpenCodeAgentOptions.openRouterPlugins?: OpenRouterPlugin[]\` so callers can opt into OpenRouter request-level plugins without an SDK change per plugin.
- \`buildOpenCodeConfig\` drops the array into the \`openrouter.options.plugins\` block of \`agentbox.json\`. The OpenRouter AI SDK spreads \`providerOptions.openrouter.*\` keys into the chat-completion request body verbatim, so the plugins reach OpenRouter without further plumbing.
- Primary use case: enable \`context-compression\` on 200K-context models so runs that overflow input + opencode's hardcoded 32K \`max_tokens\` reserve get middle-out-compressed server-side instead of failing.
- Setup-time field — changes invalidate the setup-manifest cache and re-upload \`agentbox.json\` on the next \`setup()\` call.

Consumer (e.g. twill) usage:
\`\`\`ts
await agent.setup({
  // ...
  openRouterPlugins: [{ id: "context-compression" }],
});
\`\`\`

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`vitest run test/agent-reasoning.test.ts\` — new tests cover unset, set, and empty-array cases.
- [ ] In a downstream consumer, enable \`openRouterPlugins: [{ id: "context-compression" }]\` and verify (a) the setup-manifest re-uploads, (b) a run that previously hit \`204800\` overflow now completes, (c) OpenRouter's response metadata shows the \`context_compression\` pipeline stage.