### PR TITLE
feat(opencode): per-model OpenRouter limit overrides for compaction headroom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentbox-sdk",
-  "version": "0.1.308",
+  "version": "0.1.318",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentbox-sdk",
-      "version": "0.1.308",
+      "version": "0.1.318",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.171.0",

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -358,6 +358,23 @@ export function buildOpenCodeConfig(
     transforms: ["middle-out"],
     ...(openRouterPlugins ? { plugins: openRouterPlugins } : {}),
   };
+  // Per-model `limit` overrides. opencode merges these over the models.dev
+  // catalog entry (`provider.ts` keeps catalog values for fields left
+  // unset), and `limit.input` is what flips its compaction budget from the
+  // zero-margin `context - maxOutputTokens` to `input - reserved` — see
+  // {@link OpenRouterModelLimit}.
+  const openRouterModelEntries = Object.entries(
+    options.openRouterModels ?? {},
+  ).filter(([, limit]) => limit && Object.keys(limit).length > 0);
+  const openRouterModels =
+    openRouterModelEntries.length > 0
+      ? Object.fromEntries(
+          openRouterModelEntries.map(([modelId, limit]) => [
+            modelId,
+            { limit },
+          ]),
+        )
+      : undefined;
 
   return {
     $schema: "https://opencode.ai/config.json",
@@ -369,6 +386,7 @@ export function buildOpenCodeConfig(
           baseURL: openRouterBaseUrl || "https://openrouter.ai/api/v1",
           extraBody: openRouterExtraBody,
         },
+        ...(openRouterModels ? { models: openRouterModels } : {}),
       },
       ...(googleBaseUrl
         ? { google: { options: { baseURL: googleBaseUrl } } }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -176,9 +176,43 @@ export interface OpenRouterPlugin {
   [key: string]: unknown;
 }
 
+/**
+ * Per-model token-limit overrides for opencode's openrouter provider,
+ * keyed by the bare OpenRouter model id (e.g. `z-ai/glm-5.1`).
+ *
+ * opencode auto-compacts a session when the last response's token usage
+ * reaches `usable = limit.context - maxOutputTokens` — a zero-margin
+ * threshold: the *next* request stacks new user/tool content on top of
+ * that count plus opencode's hardcoded 32K `max_tokens` reserve, so any
+ * growth between usage checks overflows the upstream window and the
+ * request 400s ("requested about 205597 tokens ... maximum context
+ * length is 204800"). OpenRouter's middle-out transform and
+ * context-compression plugin don't reliably catch sub-percent overflows,
+ * so the safety margin has to exist client-side.
+ *
+ * Setting `input` switches opencode's budget to
+ * `usable = limit.input - reserved` (`reserved` defaults to 20K), making
+ * compaction fire early enough to absorb between-check growth. Pick
+ * `input = catalog context - 32_000` so input + output reserve stays
+ * within the window with ~20K of slack. `context`/`output` override the
+ * models.dev catalog values when those are wrong for the routed endpoint.
+ */
+export interface OpenRouterModelLimit {
+  context?: number;
+  input?: number;
+  output?: number;
+}
+
 export interface OpenCodeAgentOptions extends AgentOptionsBase {
   provider?: OpenCodeProviderOptions;
   openRouterPlugins?: OpenRouterPlugin[];
+  /**
+   * Per-model `limit` overrides rendered under
+   * `provider.openrouter.models.<id>.limit` in the generated opencode
+   * config. See {@link OpenRouterModelLimit} for why these matter.
+   * Setup-time field: changing it invalidates the setup-manifest cache.
+   */
+  openRouterModels?: Record<string, OpenRouterModelLimit>;
   /**
    * Setup-time system prompt baked into the opencode agent's `prompt` field.
    *

--- a/test/agent-reasoning.test.ts
+++ b/test/agent-reasoning.test.ts
@@ -168,3 +168,60 @@ describe("buildOpenCodeConfig openRouter extraBody", () => {
     expect(options.extraBody.plugins).toBeUndefined();
   });
 });
+
+describe("buildOpenCodeConfig openRouter model limits", () => {
+  type OpenRouterProvider = {
+    options: { baseURL: string };
+    models?: Record<
+      string,
+      { limit: { context?: number; input?: number; output?: number } }
+    >;
+  };
+  const openRouterProvider = (config: unknown): OpenRouterProvider =>
+    (config as { provider: { openrouter: OpenRouterProvider } }).provider
+      .openrouter;
+
+  it("omits models when openRouterModels is unset", () => {
+    const provider = openRouterProvider(
+      buildOpenCodeConfig(makeOpenCodeRequest().options, false),
+    );
+    expect(provider.models).toBeUndefined();
+  });
+
+  it("omits models when openRouterModels is empty", () => {
+    const request = makeOpenCodeRequest();
+    request.options.openRouterModels = {};
+    const provider = openRouterProvider(
+      buildOpenCodeConfig(request.options, false),
+    );
+    expect(provider.models).toBeUndefined();
+  });
+
+  it("skips entries whose limit object is empty", () => {
+    const request = makeOpenCodeRequest();
+    request.options.openRouterModels = { "z-ai/glm-5.1": {} };
+    const provider = openRouterProvider(
+      buildOpenCodeConfig(request.options, false),
+    );
+    expect(provider.models).toBeUndefined();
+  });
+
+  it("renders per-model limit overrides under provider.openrouter.models", () => {
+    const request = makeOpenCodeRequest();
+    request.options.openRouterModels = {
+      "z-ai/glm-5.1": { input: 170_752 },
+      "moonshotai/kimi-k2.6": { context: 262_142, input: 230_142 },
+    };
+    const provider = openRouterProvider(
+      buildOpenCodeConfig(request.options, false),
+    );
+    expect(provider.models).toEqual({
+      "z-ai/glm-5.1": { limit: { input: 170_752 } },
+      "moonshotai/kimi-k2.6": {
+        limit: { context: 262_142, input: 230_142 },
+      },
+    });
+    // The options block is untouched by model overrides.
+    expect(provider.options.baseURL).toBe("https://openrouter.ai/api/v1");
+  });
+});


### PR DESCRIPTION
## Why

GLM 5.1 (and the other OpenRouter open-weight models) keep failing long runs with:

> This endpoint's maximum context length is 204800 tokens. However, you requested about 205597 tokens (158420 of text input, 15177 of tool input, 32000 in the output).

Investigation (each link verified empirically):

- opencode **does** send `transforms: ["middle-out"]` + `plugins: [{id: "context-compression"}]` via `extraBody` (verified opencode 1.16.2 against a local capture server).
- Twill's LiteLLM proxy (v1.83.14, `drop_params: true`) **does** forward both to OpenRouter (verified by running the actual proxy locally with the production config shape and capturing the upstream body).
- So OpenRouter receives the compression directives — they just don't reliably catch **sub-percent overflows** (the failing request was 797 tokens over).

The real defect is client-side accounting: opencode auto-compacts only when the **last response's** usage reaches `usable = limit.context - maxOutputTokens` (32K hardcoded reserve) — a zero-margin threshold. The next request stacks fresh user/tool content on top of that count before any new usage check can run, so between-check growth overflows the endpoint window. For `z-ai/glm-5.1` (models.dev context 202752): trigger = 170752, observed failing input = 173597. Exact match.

## What

opencode switches its budget to `usable = limit.input - reserved` (`reserved` defaults to 20K) when a model defines `limit.input` (`session/overflow.ts`), and per-model config `provider.<id>.models.<modelID>.limit` merges over the models.dev catalog.

This PR exposes that knob: `OpenCodeAgentOptions.openRouterModels` renders per-model `limit` overrides under `provider.openrouter.models` in the generated `agentbox.json`. Callers set `input = catalog context - 32_000` so compaction fires with ~20K of slack before the hard limit.

Verified against opencode 1.16.2: overrides flow through to requests (e.g. `limit.output` changes the request's `max_tokens`).

## Consumer

Twill follow-up (TwillAI/twill `fix/opencode-openrouter-compaction-headroom`) passes budgets for `z-ai/glm-5.1`, `deepseek/deepseek-v4-pro`, `moonshotai/kimi-k2.6` — needs this merged and published first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)