### PR TITLE
Fix silent run hangs: answer opencode sub-agent permission asks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentbox-sdk",
-  "version": "0.1.322",
+  "version": "0.1.501",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentbox-sdk",
-      "version": "0.1.322",
+      "version": "0.1.501",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.171.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentbox-sdk",
-  "version": "0.1.500",
+  "version": "0.1.501",
   "description": "Swappable coding agents and sandbox providers for Bun and TypeScript.",
   "license": "MIT",
   "repository": {

--- a/src/agents/config/subagents.ts
+++ b/src/agents/config/subagents.ts
@@ -66,6 +66,15 @@ function mapOpenCodeTools(
 
 export function buildOpenCodeSubagentConfig(
   subAgents: AgentSubAgentConfig[] | undefined,
+  /**
+   * Per-agent permission block, normally the same one the primary agent
+   * gets. Since opencode 1.17.2 sub-agents use their own configured
+   * permissions instead of inheriting the parent's; an entry without a
+   * `permission` block falls back to opencode's defaults (e.g.
+   * `external_directory: "ask"`), and a sub-agent's ask raised from its
+   * child session blocks the run.
+   */
+  permission?: Record<string, unknown>,
 ): Record<string, unknown> {
   return Object.fromEntries(
     (subAgents ?? []).map((subAgent) => [
@@ -74,6 +83,7 @@ export function buildOpenCodeSubagentConfig(
         mode: "subagent",
         description: subAgent.description,
         prompt: subAgent.instructions,
+        ...(permission ? { permission } : {}),
         // opencode reads a per-agent `model` as a "<providerID>/<modelID>"
         // string (e.g. "openrouter/deepseek/deepseek-v4-flash"). Without it,
         // the sub-agent silently inherits the orchestrator's model instead of

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -469,7 +469,10 @@ export function buildOpenCodeConfig(
     agent: {
       agentbox: baseAgent,
       ...reasoningVariants,
-      ...buildOpenCodeSubagentConfig(options.subAgents),
+      ...buildOpenCodeSubagentConfig(
+        options.subAgents,
+        buildOpenCodePermissionConfig(interactiveApproval),
+      ),
     },
   };
 }
@@ -1366,11 +1369,17 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"open-code"> {
             if (eventType === "permission.asked") {
               const properties = (payload as Record<string, unknown>)
                 .properties as Record<string, unknown> | undefined;
-              if (
-                properties &&
-                typeof properties.sessionID === "string" &&
-                properties.sessionID === sessionId
-              ) {
+              // Answer asks from ANY session on this server, not just the
+              // main one: sub-agents spawned via the `task` tool run in
+              // child sessions and (since opencode 1.17.2) raise their own
+              // permission events under the child sessionID. Dropping those
+              // blocks the sub-agent's tool call forever — the run then
+              // hangs emitting nothing but heartbeats. Every session on the
+              // server belongs to this run, so replying is always safe. The
+              // reply must go to the ASKING session's endpoint; opencode
+              // resolves permissions per session.
+              if (properties && typeof properties.sessionID === "string") {
+                const askingSessionId = properties.sessionID;
                 const permissionEvent = createOpenCodePermissionEvent(
                   request,
                   raw,
@@ -1384,7 +1393,7 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"open-code"> {
                     };
 
                 await fetchJson<boolean>(
-                  `${runtime.baseUrl}/session/${sessionId}/permissions/${permissionEvent.requestId}`,
+                  `${runtime.baseUrl}/session/${askingSessionId}/permissions/${permissionEvent.requestId}`,
                   {
                     method: "POST",
                     headers: {

--- a/src/agents/providers/opencode.ts
+++ b/src/agents/providers/opencode.ts
@@ -1269,6 +1269,49 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"open-code"> {
       // since assistant deltas can arrive before that message's own
       // `message.updated` notification reaches us.
       const foreignMessageIds = new Set<string>();
+      // Sessions belonging to THIS run: the main session plus every child
+      // session spawned under it (sub-agents via the `task` tool, nested
+      // arbitrarily). Grown from `session.created` events whose parent is
+      // already in the set. The `/event` stream is server-wide, so
+      // permission asks from unrelated concurrent runs must never be
+      // answered by this listener — only asks within this tree are.
+      const runSessionIds = new Set<string>([sessionId]);
+      // Fallback for asks from sessions whose `session.created` frame this
+      // listener missed (e.g. across an SSE reconnect): resolve the asking
+      // session's ancestry once via `GET /session` and cache the lineage.
+      // Any failure means "not ours" — same as the pre-existing behavior of
+      // ignoring unknown sessions.
+      const resolveRunSession = async (candidate: string): Promise<boolean> => {
+        if (runSessionIds.has(candidate)) return true;
+        try {
+          const sessions = await fetchJson<
+            Array<{ id?: string; parentID?: string }>
+          >(`${runtime.baseUrl}/session`, {
+            headers: runtime.previewHeaders,
+          });
+          if (!Array.isArray(sessions)) return false;
+          const parentById = new Map<string, string>();
+          for (const session of sessions) {
+            if (
+              typeof session?.id === "string" &&
+              typeof session?.parentID === "string"
+            ) {
+              parentById.set(session.id, session.parentID);
+            }
+          }
+          const lineage: string[] = [];
+          let cursor: string | undefined = candidate;
+          while (cursor && !runSessionIds.has(cursor) && lineage.length < 16) {
+            lineage.push(cursor);
+            cursor = parentById.get(cursor);
+          }
+          if (!cursor || !runSessionIds.has(cursor)) return false;
+          for (const id of lineage) runSessionIds.add(id);
+          return true;
+        } catch {
+          return false;
+        }
+      };
       sseTask = (async () => {
         try {
           for await (const event of streamSseResilient(
@@ -1312,6 +1355,29 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"open-code"> {
               typeof (payload as Record<string, unknown>)?.type === "string"
                 ? String((payload as Record<string, unknown>).type)
                 : event.event;
+
+            // Track child sessions spawned under this run (the `task` tool
+            // creates one per sub-agent) so permission handling below can
+            // tell this run's sessions apart from unrelated concurrent runs
+            // sharing the server-wide event bus.
+            if (
+              eventType === "session.created" ||
+              eventType === "session.updated"
+            ) {
+              const properties = (payload as Record<string, unknown>)
+                .properties as Record<string, unknown> | undefined;
+              const info = properties?.info as
+                | Record<string, unknown>
+                | undefined;
+              if (
+                info &&
+                typeof info.id === "string" &&
+                typeof info.parentID === "string" &&
+                runSessionIds.has(info.parentID)
+              ) {
+                runSessionIds.add(info.id);
+              }
+            }
 
             // Surface each user message id as a `message.started` event so
             // callers can correlate user bubbles with provider message ids.
@@ -1369,16 +1435,21 @@ export class OpenCodeAgentAdapter implements AgentProviderAdapter<"open-code"> {
             if (eventType === "permission.asked") {
               const properties = (payload as Record<string, unknown>)
                 .properties as Record<string, unknown> | undefined;
-              // Answer asks from ANY session on this server, not just the
-              // main one: sub-agents spawned via the `task` tool run in
-              // child sessions and (since opencode 1.17.2) raise their own
+              // Answer asks from any session in THIS run's session tree, not
+              // just the main one: sub-agents spawned via the `task` tool run
+              // in child sessions and (since opencode 1.17.2) raise their own
               // permission events under the child sessionID. Dropping those
-              // blocks the sub-agent's tool call forever — the run then
-              // hangs emitting nothing but heartbeats. Every session on the
-              // server belongs to this run, so replying is always safe. The
-              // reply must go to the ASKING session's endpoint; opencode
-              // resolves permissions per session.
-              if (properties && typeof properties.sessionID === "string") {
+              // blocks the sub-agent's tool call forever — the run then hangs
+              // emitting nothing but heartbeats. Sessions outside the tree
+              // belong to other runs on the shared server-wide event bus and
+              // are left to their own listeners. The reply must go to the
+              // ASKING session's endpoint; opencode resolves permissions per
+              // session.
+              if (
+                properties &&
+                typeof properties.sessionID === "string" &&
+                (await resolveRunSession(properties.sessionID))
+              ) {
                 const askingSessionId = properties.sessionID;
                 const permissionEvent = createOpenCodePermissionEvent(
                   request,

--- a/test/agent-config.test.ts
+++ b/test/agent-config.test.ts
@@ -19,7 +19,9 @@ import {
   buildOpenCodeSubagentConfig,
 } from "../src/agents/config/subagents";
 import { resolveCodexModelProviders } from "../src/agents/providers/codex";
+import { buildOpenCodeConfig } from "../src/agents/providers/opencode";
 import type { SetupLayout } from "../src/agents/config/types";
+import type { AgentOptions } from "../src/agents/types";
 
 describe("agent options config", () => {
   it("constructs an agent with shared runtime option fields", () => {
@@ -658,6 +660,83 @@ describe("config compilers", () => {
     ]);
 
     expect(config.explorer).not.toHaveProperty("model");
+  });
+
+  it("attaches the provided permission block to every opencode sub-agent", () => {
+    const permission = { external_directory: "allow", bash: "allow" };
+    const config = buildOpenCodeSubagentConfig(
+      [
+        {
+          name: "code-reviewer",
+          description: "Reviews code",
+          instructions: "Review the diff.",
+        },
+        {
+          name: "explorer",
+          description: "Explore the codebase",
+          instructions: "Find where things live.",
+        },
+      ],
+      permission,
+    );
+
+    expect(
+      (config["code-reviewer"] as Record<string, unknown>).permission,
+    ).toEqual(permission);
+    expect((config.explorer as Record<string, unknown>).permission).toEqual(
+      permission,
+    );
+  });
+
+  it("omits the permission key when none is provided", () => {
+    const config = buildOpenCodeSubagentConfig([
+      {
+        name: "explorer",
+        description: "Explore the codebase",
+        instructions: "Find where things live.",
+      },
+    ]);
+
+    expect(config.explorer).not.toHaveProperty("permission");
+  });
+
+  // Regression: since opencode 1.17.2 sub-agents use their own configured
+  // permissions instead of inheriting the parent's. A sub-agent entry
+  // without a permission block falls back to opencode's default
+  // `external_directory: "ask"`, and the ask (raised from the sub-agent's
+  // child session) was never answered — the run hung forever on the blocked
+  // `task` tool call.
+  it("gives opencode sub-agents the primary agent's permission config", () => {
+    const options = {
+      subAgents: [
+        {
+          name: "code-reviewer",
+          description: "Reviews code",
+          instructions: "Review the diff.",
+        },
+      ],
+    } as AgentOptions<"open-code">;
+
+    const autoConfig = buildOpenCodeConfig(options, false);
+    const autoAgents = autoConfig.agent as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(autoAgents["code-reviewer"]!.permission).toEqual(
+      autoAgents.agentbox!.permission,
+    );
+    expect(autoAgents["code-reviewer"]!.permission).toMatchObject({
+      external_directory: "allow",
+    });
+
+    const interactiveConfig = buildOpenCodeConfig(options, true);
+    const interactiveAgents = interactiveConfig.agent as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(interactiveAgents["code-reviewer"]!.permission).toMatchObject({
+      external_directory: "ask",
+    });
   });
 });
 

--- a/test/opencode-prompt-async.test.ts
+++ b/test/opencode-prompt-async.test.ts
@@ -22,6 +22,8 @@ interface FakeOpenCodeServer {
     permissionId: string;
     body: unknown;
   }>;
+  /** Sessions returned by `GET /session` (id + parentID lineage). */
+  sessions: Array<{ id: string; parentID?: string }>;
   pushEvent(frame: SseFrame): void;
   close(): Promise<void>;
   /** Set this to make the next prompt_async call respond with the given status. */
@@ -33,6 +35,7 @@ interface FakeOpenCodeServer {
 async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
   const promptAsyncRequests: FakeOpenCodeServer["promptAsyncRequests"] = [];
   const permissionResponses: FakeOpenCodeServer["permissionResponses"] = [];
+  const sessions: FakeOpenCodeServer["sessions"] = [];
   const eventClients: Array<NodeJS.WritableStream & { end?: () => void }> = [];
   const queuedFrames: SseFrame[] = [];
 
@@ -48,6 +51,7 @@ async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
     baseUrl: "",
     promptAsyncRequests,
     permissionResponses,
+    sessions,
     pushEvent(frame) {
       queuedFrames.push(frame);
       for (const client of eventClients) {
@@ -86,6 +90,12 @@ async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
     if (method === "POST" && url === "/session") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ id: "ses_test" }));
+      return;
+    }
+
+    if (method === "GET" && url === "/session") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(sessions));
       return;
     }
 
@@ -311,11 +321,24 @@ describe("opencode prompt_async + SSE", () => {
   // and (since opencode 1.17.2) raise their own permission.asked events under
   // the child sessionID. The adapter used to only answer asks from the main
   // session, so a sub-agent's ask was dropped and the run hung forever on the
-  // blocked tool call, emitting nothing but heartbeats.
-  it("answers permission.asked from a sub-agent child session at that session's endpoint", async () => {
+  // blocked tool call, emitting nothing but heartbeats. The /event bus is
+  // server-wide, though, so asks from sessions OUTSIDE this run's tree must
+  // stay unanswered — they belong to other runs' listeners.
+  it("answers permission.asked from this run's session tree only, at the asking session's endpoint", async () => {
     fake = await startFakeOpenCodeServer();
     const adapter = new OpenCodeAgentAdapter();
     const { sink, finished } = makeCapturingSink();
+
+    // `GET /session` lineage: ses_lostchild is ours (its session.created
+    // frame is never streamed, simulating an SSE reconnect gap); ses_foreign
+    // belongs to a different run's root session.
+    fake.sessions.push(
+      { id: "ses_test" },
+      { id: "ses_child", parentID: "ses_test" },
+      { id: "ses_lostchild", parentID: "ses_test" },
+      { id: "ses_other" },
+      { id: "ses_foreign", parentID: "ses_other" },
+    );
 
     const request = makeRequest({
       options: {
@@ -328,6 +351,16 @@ describe("opencode prompt_async + SSE", () => {
     const executePromise = adapter.execute(request, sink);
     await new Promise((r) => setTimeout(r, 100));
 
+    // The `task` tool spawns the sub-agent's child session.
+    fake.pushEvent({
+      event: "session.created",
+      data: {
+        type: "session.created",
+        properties: {
+          info: { id: "ses_child", parentID: "ses_test" },
+        },
+      },
+    });
     // A permission ask from the MAIN session (pre-existing behavior).
     fake.pushEvent({
       event: "permission.asked",
@@ -355,9 +388,36 @@ describe("opencode prompt_async + SSE", () => {
         },
       },
     });
+    // A child whose session.created frame was missed: resolved via
+    // `GET /session` lineage instead.
+    fake.pushEvent({
+      event: "permission.asked",
+      data: {
+        type: "permission.asked",
+        properties: {
+          id: "per_lost",
+          sessionID: "ses_lostchild",
+          permission: "external_directory",
+          patterns: ["/tmp/*"],
+        },
+      },
+    });
+    // Another run's session on the shared bus: must NOT be answered.
+    fake.pushEvent({
+      event: "permission.asked",
+      data: {
+        type: "permission.asked",
+        properties: {
+          id: "per_foreign",
+          sessionID: "ses_foreign",
+          permission: "external_directory",
+          patterns: ["/tmp/*"],
+        },
+      },
+    });
 
-    // Give the adapter time to POST both permission responses.
-    await new Promise((r) => setTimeout(r, 200));
+    // Give the adapter time to POST the permission responses.
+    await new Promise((r) => setTimeout(r, 300));
 
     fake.pushEvent({
       event: "session.idle",
@@ -380,6 +440,11 @@ describe("opencode prompt_async + SSE", () => {
       permissionId: "per_child",
       body: { response: "once" },
     });
+    expect(bySession.ses_lostchild).toMatchObject({
+      permissionId: "per_lost",
+      body: { response: "once" },
+    });
+    expect(bySession).not.toHaveProperty("ses_foreign");
   });
 
   it("emits message.completed per assistant message and resolves to the LAST message text", async () => {

--- a/test/opencode-prompt-async.test.ts
+++ b/test/opencode-prompt-async.test.ts
@@ -17,6 +17,11 @@ type SseFrame = { event: string; data: unknown; id?: string };
 interface FakeOpenCodeServer {
   baseUrl: string;
   promptAsyncRequests: Array<{ body: unknown; sessionId: string }>;
+  permissionResponses: Array<{
+    sessionId: string;
+    permissionId: string;
+    body: unknown;
+  }>;
   pushEvent(frame: SseFrame): void;
   close(): Promise<void>;
   /** Set this to make the next prompt_async call respond with the given status. */
@@ -27,6 +32,7 @@ interface FakeOpenCodeServer {
 
 async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
   const promptAsyncRequests: FakeOpenCodeServer["promptAsyncRequests"] = [];
+  const permissionResponses: FakeOpenCodeServer["permissionResponses"] = [];
   const eventClients: Array<NodeJS.WritableStream & { end?: () => void }> = [];
   const queuedFrames: SseFrame[] = [];
 
@@ -41,6 +47,7 @@ async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
   const fake: FakeOpenCodeServer = {
     baseUrl: "",
     promptAsyncRequests,
+    permissionResponses,
     pushEvent(frame) {
       queuedFrames.push(frame);
       for (const client of eventClients) {
@@ -97,6 +104,21 @@ async function startFakeOpenCodeServer(): Promise<FakeOpenCodeServer> {
     }
 
     if (method === "POST" && /^\/session\/[^/]+\/abort$/.test(url)) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("true");
+      return;
+    }
+
+    const permissionMatch = url.match(
+      /^\/session\/([^/]+)\/permissions\/([^/]+)$/,
+    );
+    if (method === "POST" && permissionMatch) {
+      const body = await readJson(req).catch(() => ({}));
+      permissionResponses.push({
+        sessionId: decodeURIComponent(permissionMatch[1] ?? ""),
+        permissionId: decodeURIComponent(permissionMatch[2] ?? ""),
+        body,
+      });
       res.writeHead(200, { "content-type": "application/json" });
       res.end("true");
       return;
@@ -283,6 +305,81 @@ describe("opencode prompt_async + SSE", () => {
     const eventTypes = events.map((e) => e.type);
     expect(eventTypes).toContain("text.delta");
     expect(eventTypes).toContain("run.completed");
+  });
+
+  // Regression: sub-agents spawned via the `task` tool run in child sessions
+  // and (since opencode 1.17.2) raise their own permission.asked events under
+  // the child sessionID. The adapter used to only answer asks from the main
+  // session, so a sub-agent's ask was dropped and the run hung forever on the
+  // blocked tool call, emitting nothing but heartbeats.
+  it("answers permission.asked from a sub-agent child session at that session's endpoint", async () => {
+    fake = await startFakeOpenCodeServer();
+    const adapter = new OpenCodeAgentAdapter();
+    const { sink, finished } = makeCapturingSink();
+
+    const request = makeRequest({
+      options: {
+        cwd: "/tmp",
+        approvalMode: "auto",
+        sandbox: makeFakeSandbox(fake.baseUrl),
+      },
+    });
+
+    const executePromise = adapter.execute(request, sink);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // A permission ask from the MAIN session (pre-existing behavior).
+    fake.pushEvent({
+      event: "permission.asked",
+      data: {
+        type: "permission.asked",
+        properties: {
+          id: "per_main",
+          sessionID: "ses_test",
+          permission: "external_directory",
+          patterns: ["/tmp/*"],
+        },
+      },
+    });
+    // A permission ask from a sub-agent CHILD session (the hang case).
+    fake.pushEvent({
+      event: "permission.asked",
+      data: {
+        type: "permission.asked",
+        properties: {
+          id: "per_child",
+          sessionID: "ses_child",
+          permission: "external_directory",
+          patterns: ["/tmp/*"],
+          metadata: { filepath: "/tmp/full.diff" },
+        },
+      },
+    });
+
+    // Give the adapter time to POST both permission responses.
+    await new Promise((r) => setTimeout(r, 200));
+
+    fake.pushEvent({
+      event: "session.idle",
+      data: { type: "session.idle", properties: { sessionID: "ses_test" } },
+    });
+
+    const result = await finished;
+    await executePromise;
+    expect(result.kind).toBe("complete");
+
+    const bySession = Object.fromEntries(
+      fake.permissionResponses.map((p) => [p.sessionId, p]),
+    );
+    expect(bySession.ses_test).toMatchObject({
+      permissionId: "per_main",
+      body: { response: "once" },
+    });
+    // The child-session ask must be answered at the CHILD session's endpoint.
+    expect(bySession.ses_child).toMatchObject({
+      permissionId: "per_child",
+      body: { response: "once" },
+    });
   });
 
   it("emits message.completed per assistant message and resolves to the LAST message text", async () => {


### PR DESCRIPTION
## Summary

Root-cause fix for the silent job hangs reported by CoSprite on 2026-07-11 (Twill RCA: TwillAI/Twill#1048, mitigation PR: TwillAI/Twill#1049).

When an opencode sub-agent (spawned via the `task` tool) touches a path outside the workspace, opencode raises `permission.asked` from the sub-agent's **child session**. The SDK dropped those asks, the sub-agent's tool call blocked forever, and the run hung emitting nothing but heartbeats — the SDK's own SSE-silence guard never trips because heartbeats reset `lastSseActivityAt`.

## The two defects

1. **Sub-agents got no permission config.** `buildOpenCodeSubagentConfig` emitted `{mode, description, prompt, model?, tools?}` with no `permission` block. Since opencode 1.17.2 ("Let subagents use their own configured permissions again") sub-agents use their own configured permissions instead of inheriting the parent's, so child sessions fell back to the default `external_directory: "ask"`.
2. **The `permission.asked` handler was main-session-only.** It filtered on `properties.sessionID === sessionId` and POSTed replies to the main session's endpoint, so child-session asks could never be answered.

## Fixes

- `buildOpenCodeSubagentConfig(subAgents, permission?)` attaches the given permission block to every sub-agent entry; `buildOpenCodeConfig` passes the same `buildOpenCodePermissionConfig(interactiveApproval)` the primary agent gets. Under `approvalMode: "auto"` the ask is never raised at all.
- The SSE handler now answers `permission.asked` from any session in **this run's session tree** (main session + children announced via `session.created`, with a `GET /session` lineage fallback for creation frames missed across SSE reconnects) and POSTs the reply to the **asking** session's endpoint. Asks from sessions outside the tree (other concurrent runs on the shared server-wide event bus) are ignored. Interactive mode keeps forwarding to `sink.requestPermission` unchanged.

## Testing

- New config tests: sub-agent entries carry the permission block (auto → `external_directory: "allow"`, interactive → `"ask"`), and omit it when none is given.
- New adapter regression test: a `permission.asked` from a child session (`ses_child`, the exact `/tmp/full.diff` shape from the production traces) is answered at `/session/ses_child/permissions/per_child` with `"once"`, alongside the main-session case.
- `npm run typecheck`, `npm run lint`, `vitest run`: 145 passed, 20 skipped (e2e).

Production impact: confirmed hung jobs of 54 min and 4.2 h (users cancelled manually); the trigger was the code-reviewer sub-agent writing `/tmp/full.diff` or reading `/root/.twill/approved-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
