### PR TITLE
feat(sandboxes): add Tenki sandbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Studio support; chat-only backends need a responses→chat proxy.
 
 ## Sandboxes
 
-Five sandbox providers are supported. Each gives you an isolated environment with the same interface:
+Six sandbox providers are supported. Each gives you an isolated environment with the same interface:
 
 | Provider       | What it is             | Auth                                                    |
 | -------------- | ---------------------- | ------------------------------------------------------- |
@@ -212,6 +212,7 @@ Five sandbox providers are supported. Each gives you an isolated environment wit
 | `modal`        | Cloud container        | `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET`                 |
 | `daytona`      | Cloud dev environment  | `DAYTONA_API_KEY`                                       |
 | `vercel`       | Ephemeral cloud VM     | `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID` |
+| `tenki`        | Cloud micro-VM         | `TENKI_API_KEY` (or `TENKI_AUTH_TOKEN`)                 |
 
 Every sandbox supports: `findOrProvision()`, `run()`, `runAsync()`, `gitClone()`, `uploadAndRun()`, `openPort()`, `getPreviewLink()`, `snapshot()`, `stop()`, `delete()`.
 
@@ -243,6 +244,31 @@ const sandbox = new Sandbox("vercel", {
   },
 });
 ```
+
+### Tenki
+
+[Tenki](https://tenki.cloud) sandboxes are Linux micro-VMs created via [`@tenkicloud/sandbox`](https://www.npmjs.com/package/@tenkicloud/sandbox). Authenticate with a workspace API key (prefixed `tk_`), passed via `provider.apiKey` or the `TENKI_API_KEY` / `TENKI_AUTH_TOKEN` environment variables:
+
+```ts
+const sandbox = new Sandbox("tenki", {
+  workingDir: "/workspace", // created automatically; defaults to /home/tenki
+  resources: { cpu: 2, memoryMiB: 4096 },
+  provider: {
+    apiKey: process.env.TENKI_API_KEY, // optional when the env var is set
+    allowInbound: true, // default; required for getPreviewLink()
+    allowOutbound: true, // default
+  },
+});
+```
+
+`TenkiProviderOptions` also supports `baseUrl`, `workspaceId`, `name`, `cpuCores` / `memoryMb` (override `resources`), `sshAuthorizedKeys`, `snapshotId` (restore from a snapshot), `previewTtlMs` (expiry for preview URLs), and `createParams` — an escape hatch spread into the SDK's `createAndWait()` for fields not surfaced here (e.g. `volumes`, `diskSizeGb`, `enableOpenCode`).
+
+Notes:
+
+- Sessions are found and reused by `tags` (stored in Tenki session metadata); `stop()` pauses the micro-VM and a later `findOrProvision()` resumes it. Sessions are billed resources — call `delete()` when done.
+- `options.image` accepts a Tenki registry ref; `snapshot()` returns a snapshot id usable via `provider.snapshotId`.
+- Ports are exposed dynamically — `openPort()` / `getPreviewLink()` work at runtime, no up-front declaration needed.
+- Command timeouts are enforced client-side, and `kill()` signals the spawned shell (not descendants of compound commands) — both are platform limitations of the current Tenki API.
 
 ## Skills
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.171.0",
+        "@tenkicloud/sandbox": "^0.4.0",
         "@types/debug": "^4.1.13",
         "@vercel/sandbox": "2.0.0-beta.13",
         "debug": "^4.4.3",
@@ -1097,9 +1098,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
@@ -3925,6 +3926,43 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tenkicloud/sandbox": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.4.0.tgz",
+      "integrity": "sha512-p9GiQutfqEhEEAQlEOph/wuP2Vk0kDof4GjhIvnV96TbvzoqPFp1pD6iEjUcJMri6sJsEXBGf0Grsyl+X52GiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.1",
+        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect-node": "2.1.2",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@types/chai": {
@@ -9111,9 +9149,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.171.0",
-        "@tenkicloud/sandbox": "^0.4.0",
+        "@tenkicloud/sandbox": "^0.5.4",
         "@types/debug": "^4.1.13",
         "@vercel/sandbox": "2.0.0-beta.13",
         "debug": "^4.4.3",
@@ -3929,15 +3929,15 @@
       }
     },
     "node_modules/@tenkicloud/sandbox": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.4.0.tgz",
-      "integrity": "sha512-p9GiQutfqEhEEAQlEOph/wuP2Vk0kDof4GjhIvnV96TbvzoqPFp1pD6iEjUcJMri6sJsEXBGf0Grsyl+X52GiA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.5.4.tgz",
+      "integrity": "sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "2.12.1",
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-node": "2.1.2",
-        "ws": "8.21.0"
+        "ws": "8.21.1"
       },
       "engines": {
         "node": ">=18"
@@ -9149,9 +9149,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.171.0",
+    "@tenkicloud/sandbox": "^0.4.0",
     "@types/debug": "^4.1.13",
     "@vercel/sandbox": "2.0.0-beta.13",
     "debug": "^4.4.3",
@@ -97,6 +98,7 @@
     "daytona",
     "docker",
     "vercel",
+    "tenki",
     "typescript",
     "bun"
   ]

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "^0.171.0",
-    "@tenkicloud/sandbox": "^0.4.0",
+    "@tenkicloud/sandbox": "^0.5.4",
     "@types/debug": "^4.1.13",
     "@vercel/sandbox": "2.0.0-beta.13",
     "debug": "^4.4.3",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -21,6 +21,7 @@ export const SandboxProvider = {
   Daytona: "daytona",
   Vercel: "vercel",
   E2B: "e2b",
+  Tenki: "tenki",
 } as const;
 export type SandboxProvider =
   (typeof SandboxProvider)[keyof typeof SandboxProvider];

--- a/src/sandboxes/Sandbox.ts
+++ b/src/sandboxes/Sandbox.ts
@@ -2,6 +2,7 @@ import { DaytonaSandboxAdapter } from "./providers/daytona";
 import { E2bSandboxAdapter } from "./providers/e2b";
 import { LocalDockerSandboxAdapter } from "./providers/local-docker";
 import { ModalSandboxAdapter } from "./providers/modal";
+import { TenkiSandboxAdapter } from "./providers/tenki";
 import { VercelSandboxAdapter } from "./providers/vercel";
 import {
   SandboxProvider,
@@ -50,6 +51,10 @@ function createSandboxAdapter<P extends SandboxProviderName>(
     case SandboxProvider.E2B:
       return new E2bSandboxAdapter(
         options as SandboxOptions<"e2b">,
+      ) as unknown as SandboxAdapter<P, SandboxOptions<P>, SandboxRaw<P>>;
+    case SandboxProvider.Tenki:
+      return new TenkiSandboxAdapter(
+        options as SandboxOptions<"tenki">,
       ) as unknown as SandboxAdapter<P, SandboxOptions<P>, SandboxRaw<P>>;
     default:
       throw new UnsupportedProviderError("sandbox", provider);

--- a/src/sandboxes/providers/tenki.ts
+++ b/src/sandboxes/providers/tenki.ts
@@ -2,8 +2,6 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import {
-  isTerminal,
-  isReady,
   TenkiSandbox as TenkiClient,
   type CreateOptions,
   type ProcessRunHandle,
@@ -23,7 +21,6 @@ import {
   type TenkiSandboxOptions,
 } from "../types";
 import { AsyncQueue } from "../../shared/async-queue";
-import { debugSandbox } from "../../shared/debug";
 import { asError, suppressUnhandledRejection } from "../../shared/errors";
 import { pipeReadableStream } from "../../shared/streams";
 import { shellQuote, toShellCommand } from "../../shared/shell";
@@ -59,6 +56,25 @@ function bytesToStream(data: Uint8Array): ReadableStream<Uint8Array> {
   });
 }
 
+const SESSION_GONE_ERRORS = new Set([
+  "SessionNotFoundError",
+  "SessionExpiredError",
+  "SessionTerminatedError",
+]);
+
+const WARM_REUSABLE_STATES = new Set<string>([
+  "RUNNING",
+  "PAUSED",
+  "CREATING",
+  "RESUMING",
+]);
+
+const PREVIEW_EXPIRY_MARGIN_MS = 5_000;
+
+function isSessionGone(error: unknown): boolean {
+  return error instanceof Error && SESSION_GONE_ERRORS.has(error.name);
+}
+
 function matchesAllTags(
   candidate: Record<string, string> | undefined,
   required: Record<string, string>,
@@ -76,7 +92,10 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
   private readonly client: TenkiClient;
   private session?: Session;
   private clientClosed = false;
-  private readonly previewLinks = new Map<number, string>();
+  private readonly previewLinks = new Map<
+    number,
+    { url: string; expiresAtMs?: number }
+  >();
 
   constructor(options: TenkiSandboxOptions) {
     super(options);
@@ -120,8 +139,10 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
     if (existing) {
       this.session = existing;
       this.isWarmFlag = true;
-      if (!isReady(existing.state)) {
+      if (existing.state === "PAUSED") {
         await existing.resume();
+      } else if (existing.state !== "RUNNING") {
+        await existing.waitReady();
       }
       return;
     }
@@ -176,20 +197,26 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
     this.session = session;
 
     if (this.workingDir !== TENKI_FS_ROOT) {
-      const dir = shellQuote(this.workingDir);
-      const result = await session.run(
-        [
-          "/bin/sh",
-          "-c",
-          `mkdir -p ${dir} && chown --reference=${TENKI_FS_ROOT} ${dir}`,
-        ],
-        { privileged: true },
-      );
-      if (result.exitCode !== 0) {
-        throw new Error(
-          `Failed to create Tenki working directory ${this.workingDir} ` +
-            `(exit ${result.exitCode}): ${decoder.decode(result.stderr).trim()}`,
+      try {
+        const dir = shellQuote(this.workingDir);
+        const result = await session.run(
+          [
+            "/bin/sh",
+            "-c",
+            `mkdir -p ${dir} && chown --reference=${TENKI_FS_ROOT} ${dir}`,
+          ],
+          { privileged: true },
         );
+        if (result.exitCode !== 0) {
+          throw new Error(
+            `Failed to create Tenki working directory ${this.workingDir} ` +
+              `(exit ${result.exitCode}): ${decoder.decode(result.stderr).trim()}`,
+          );
+        }
+      } catch (error) {
+        this.session = undefined;
+        await session.close().catch(() => undefined);
+        throw asError(error);
       }
     }
   }
@@ -308,11 +335,34 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
     suppressUnhandledRejection(completion);
 
     let killedResolve: ((result: CommandResult) => void) | undefined;
-    const killedResult = new Promise<CommandResult>((resolve) => {
+    let timeoutReject: ((error: Error) => void) | undefined;
+    const settledEarly = new Promise<CommandResult>((resolve, reject) => {
       killedResolve = resolve;
+      timeoutReject = reject;
     });
-    const settled = Promise.race([completion, killedResult]);
+    const settled = Promise.race([completion, settledEarly]);
     suppressUnhandledRejection(settled);
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const clearTimer = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+    void completion.then(clearTimer, clearTimer);
+
+    const timeoutMs = options?.timeoutMs;
+    if (timeoutMs && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        void handle.kill().catch(() => undefined);
+        const error = new Error(
+          `Tenki command timed out after ${timeoutMs}ms: ${toShellCommand(command)}`,
+        );
+        queue.fail(error);
+        timeoutReject?.(error);
+      }, timeoutMs);
+    }
 
     let stdinWriter: WritableStreamDefaultWriter<Uint8Array> | undefined;
 
@@ -327,6 +377,7 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
       },
       wait: () => settled,
       kill: async () => {
+        clearTimer();
         await handle.kill().catch(() => undefined);
         queue.push({
           type: "exit",
@@ -439,54 +490,62 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
 
   async delete(): Promise<void> {
     const session = this.session;
-    this.session = undefined;
-    this.previewLinks.clear();
     if (session) {
-      await session.close().catch(() => undefined);
+      try {
+        await session.close();
+      } catch (error) {
+        if (!isSessionGone(error)) {
+          throw asError(error);
+        }
+      }
+      this.session = undefined;
+      this.previewLinks.clear();
     }
     this.closeClient();
   }
 
   async openPort(port: number): Promise<void> {
     this.requireProvisioned();
-    const session = this.requireSession();
-    const exposed = await session.exposePort(port, this.previewPortOptions());
-    this.previewLinks.set(port, exposed.previewUrl);
+    await this.exposePreviewLink(port);
   }
 
   async getPreviewLink(port: number): Promise<string> {
     this.requireProvisioned();
     const cached = this.previewLinks.get(port);
-    if (cached) {
-      return cached;
+    if (
+      cached &&
+      (cached.expiresAtMs === undefined ||
+        cached.expiresAtMs - PREVIEW_EXPIRY_MARGIN_MS > Date.now())
+    ) {
+      return cached.url;
     }
-    const session = this.requireSession();
-    const exposed = await session.exposePort(port, this.previewPortOptions());
-    this.previewLinks.set(port, exposed.previewUrl);
-    return exposed.previewUrl;
+    return this.exposePreviewLink(port);
   }
 
-  private previewPortOptions(): { ttlMs: number } | undefined {
+  private async exposePreviewLink(port: number): Promise<string> {
+    const session = this.requireSession();
     const ttlMs = this.options.provider?.previewTtlMs;
-    return ttlMs ? { ttlMs } : undefined;
+    const exposed = await session.exposePort(
+      port,
+      ttlMs ? { ttlMs } : undefined,
+    );
+    const expiresAtMs =
+      exposed.expiresAt?.getTime() ?? (ttlMs ? Date.now() + ttlMs : undefined);
+    this.previewLinks.set(port, { url: exposed.previewUrl, expiresAtMs });
+    return exposed.previewUrl;
   }
 
   private async findMatchingSession(
     desiredTags: Record<string, string>,
   ): Promise<Session | undefined> {
-    try {
-      const sessions = await this.client.list({
-        tags: [this.providerMarker()],
-      });
-      return sessions.find(
-        (session) =>
-          !isTerminal(session.state) &&
-          matchesAllTags(session.metadata, desiredTags),
-      );
-    } catch (error) {
-      debugSandbox("tenki warm-reuse lookup failed: %o", error);
-      return undefined;
-    }
+    const sessions = await this.client.list({
+      tags: [this.providerMarker()],
+    });
+    return sessions.find(
+      (session) =>
+        WARM_REUSABLE_STATES.has(session.state) &&
+        matchesAllTags(session.metadata, desiredTags),
+    );
   }
 
   private getTags(): Record<string, string> {

--- a/src/sandboxes/providers/tenki.ts
+++ b/src/sandboxes/providers/tenki.ts
@@ -1,0 +1,561 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import {
+  isTerminal,
+  isReady,
+  TenkiSandbox as TenkiClient,
+  type CreateOptions,
+  type ProcessRunHandle,
+  type ProcessRunResult,
+  type Session,
+} from "@tenkicloud/sandbox";
+
+import { SandboxAdapter } from "../base";
+import {
+  SandboxProvider,
+  type AsyncCommandHandle,
+  type CommandEvent,
+  type CommandOptions,
+  type CommandResult,
+  type SandboxDescriptor,
+  type SandboxListOptions,
+  type TenkiSandboxOptions,
+} from "../types";
+import { AsyncQueue } from "../../shared/async-queue";
+import { debugSandbox } from "../../shared/debug";
+import { asError, suppressUnhandledRejection } from "../../shared/errors";
+import { pipeReadableStream } from "../../shared/streams";
+import { shellQuote, toShellCommand } from "../../shared/shell";
+import { resolveSandboxImage, resolveSandboxResources } from "../image-utils";
+
+export type TenkiRaw = {
+  client: TenkiClient;
+  session?: Session;
+};
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+const TENKI_FS_ROOT = "/home/tenki";
+
+function isUnderFsRoot(absolutePath: string): boolean {
+  const normalized = path.posix.normalize(absolutePath);
+  return (
+    normalized === TENKI_FS_ROOT || normalized.startsWith(`${TENKI_FS_ROOT}/`)
+  );
+}
+
+function shellArgv(command: string | string[]): string[] {
+  return ["/bin/sh", "-lc", toShellCommand(command)];
+}
+
+function bytesToStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+}
+
+function matchesAllTags(
+  candidate: Record<string, string> | undefined,
+  required: Record<string, string>,
+): boolean {
+  return Object.entries(required).every(
+    ([key, value]) => candidate?.[key] === value,
+  );
+}
+
+export class TenkiSandboxAdapter extends SandboxAdapter<
+  "tenki",
+  TenkiSandboxOptions,
+  TenkiRaw
+> {
+  private readonly client: TenkiClient;
+  private session?: Session;
+  private clientClosed = false;
+  private projectContext?: { workspaceId?: string; projectId?: string };
+  private readonly previewLinks = new Map<number, string>();
+
+  constructor(options: TenkiSandboxOptions) {
+    super(options);
+
+    const provider = options.provider;
+    const authToken =
+      provider?.apiKey ??
+      provider?.authToken ??
+      process.env.TENKI_API_KEY ??
+      process.env.TENKI_AUTH_TOKEN;
+
+    this.client = new TenkiClient({
+      ...(authToken ? { authToken } : {}),
+      ...(provider?.baseUrl ? { baseUrl: provider.baseUrl } : {}),
+    });
+  }
+
+  get provider(): "tenki" {
+    return SandboxProvider.Tenki;
+  }
+
+  get raw(): TenkiRaw {
+    return {
+      client: this.client,
+      session: this.session,
+    };
+  }
+
+  get id(): string | undefined {
+    return this.session?.id;
+  }
+
+  override get workingDir(): string {
+    return this.options.workingDir ?? TENKI_FS_ROOT;
+  }
+
+  protected async provision(): Promise<void> {
+    const tags = this.getTags();
+
+    const existing = await this.findMatchingSession(tags);
+    if (existing) {
+      this.session = existing;
+      this.isWarmFlag = true;
+      if (!isReady(existing.state)) {
+        await existing.resume();
+      }
+      return;
+    }
+
+    const provider = this.options.provider;
+    const resources = resolveSandboxResources(this.options.resources);
+
+    const createOptions: CreateOptions = {
+      ...(provider?.createParams ?? {}),
+      allowInbound: provider?.allowInbound ?? true,
+      allowOutbound: provider?.allowOutbound ?? true,
+      env: this.getMergedEnv(),
+      metadata: tags,
+      tags: [this.providerMarker()],
+    };
+
+    createOptions.name =
+      provider?.name ?? `agentbox-${randomUUID().slice(0, 8)}`;
+    const cpuCores = provider?.cpuCores ?? resources?.cpu;
+    if (cpuCores !== undefined) {
+      createOptions.cpuCores = cpuCores;
+    }
+    const memoryMb = provider?.memoryMb ?? resources?.memoryMiB;
+    if (memoryMb !== undefined) {
+      createOptions.memoryMb = memoryMb;
+    }
+    if (provider?.sshAuthorizedKeys !== undefined) {
+      createOptions.sshAuthorizedKeys = provider.sshAuthorizedKeys;
+    }
+    const image = resolveSandboxImage(this.options.image);
+    if (image !== undefined) {
+      createOptions.image = image;
+    }
+    if (provider?.snapshotId !== undefined) {
+      createOptions.snapshotId = provider.snapshotId;
+    }
+    if (this.options.idleTimeoutMs !== undefined) {
+      createOptions.idleTimeoutMinutes = Math.max(
+        1,
+        Math.ceil(this.options.idleTimeoutMs / 60_000),
+      );
+    }
+    if (this.options.autoStopMs !== undefined) {
+      createOptions.maxDurationMs = this.options.autoStopMs;
+    }
+
+    const context = await this.resolveProjectContext();
+    if (context.workspaceId !== undefined) {
+      createOptions.workspaceId = context.workspaceId;
+    }
+    if (context.projectId !== undefined) {
+      createOptions.projectId = context.projectId;
+    }
+
+    const session = await this.client.createAndWait(createOptions);
+    this.session = session;
+
+    if (this.workingDir !== TENKI_FS_ROOT) {
+      const dir = shellQuote(this.workingDir);
+      const result = await session.run(
+        [
+          "/bin/sh",
+          "-c",
+          `mkdir -p ${dir} && chown --reference=${TENKI_FS_ROOT} ${dir}`,
+        ],
+        { privileged: true },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `Failed to create Tenki working directory ${this.workingDir} ` +
+            `(exit ${result.exitCode}): ${decoder.decode(result.stderr).trim()}`,
+        );
+      }
+    }
+  }
+
+  private async resolveProjectContext(): Promise<{
+    workspaceId?: string;
+    projectId?: string;
+  }> {
+    const provider = this.options.provider;
+    if (provider?.projectId) {
+      return {
+        workspaceId: provider.workspaceId,
+        projectId: provider.projectId,
+      };
+    }
+    if (this.projectContext) {
+      return this.projectContext;
+    }
+
+    const identity = await this.client.whoAmI();
+    const workspace =
+      (provider?.workspaceId
+        ? identity.workspaces.find((w) => w.id === provider.workspaceId)
+        : undefined) ?? identity.workspaces[0];
+    const project = workspace?.projects[0];
+    if (!workspace || !project) {
+      throw new Error(
+        "Tenki: could not resolve a default project. " +
+          "Set `provider.projectId` (and optionally `provider.workspaceId`).",
+      );
+    }
+
+    this.projectContext = {
+      workspaceId: workspace.id,
+      projectId: project.id,
+    };
+    return this.projectContext;
+  }
+
+  async run(
+    command: string | string[],
+    options?: CommandOptions,
+  ): Promise<CommandResult> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+
+    const handle = session.run(shellArgv(command), {
+      cwd: options?.cwd ?? this.workingDir,
+      env: this.getMergedEnv(options?.env),
+    });
+
+    const result = await this.awaitHandle(handle, command, options?.timeoutMs);
+    const stdout = decoder.decode(result.stdout);
+    const stderr = decoder.decode(result.stderr);
+
+    return {
+      exitCode: result.exitCode,
+      stdout,
+      stderr,
+      combinedOutput: `${stdout}${stderr}`,
+      raw: result,
+    };
+  }
+
+  private async awaitHandle(
+    handle: ProcessRunHandle,
+    command: string | string[],
+    timeoutMs: number | undefined,
+  ): Promise<ProcessRunResult> {
+    if (!timeoutMs || timeoutMs <= 0) {
+      return handle;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        void handle.kill().catch(() => undefined);
+        reject(
+          new Error(
+            `Tenki command timed out after ${timeoutMs}ms: ${toShellCommand(command)}`,
+          ),
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([handle, timeout]);
+    } catch (error) {
+      throw asError(error);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async runAsync(
+    command: string | string[],
+    options?: CommandOptions,
+  ): Promise<AsyncCommandHandle> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+
+    const handle = session.run(shellArgv(command), {
+      cwd: options?.cwd ?? this.workingDir,
+      env: this.getMergedEnv(options?.env),
+    });
+
+    const queue = new AsyncQueue<CommandEvent>();
+    let stdout = "";
+    let stderr = "";
+
+    const stdoutPump = pipeReadableStream(handle.stdout, (chunk) => {
+      stdout += chunk;
+      queue.push({
+        type: "stdout",
+        chunk,
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    const stderrPump = pipeReadableStream(handle.stderr, (chunk) => {
+      stderr += chunk;
+      queue.push({
+        type: "stderr",
+        chunk,
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    const completion = Promise.all([stdoutPump, stderrPump, handle])
+      .then(([, , result]) => {
+        queue.push({
+          type: "exit",
+          exitCode: result.exitCode,
+          timestamp: new Date().toISOString(),
+        });
+        queue.finish();
+
+        return {
+          exitCode: result.exitCode,
+          stdout,
+          stderr,
+          combinedOutput: `${stdout}${stderr}`,
+          raw: result,
+        } satisfies CommandResult;
+      })
+      .catch((error) => {
+        queue.fail(error);
+        throw error;
+      });
+
+    suppressUnhandledRejection(completion);
+
+    let killedResolve: ((result: CommandResult) => void) | undefined;
+    const killedResult = new Promise<CommandResult>((resolve) => {
+      killedResolve = resolve;
+    });
+    const settled = Promise.race([completion, killedResult]);
+    suppressUnhandledRejection(settled);
+
+    let stdinWriter: WritableStreamDefaultWriter<Uint8Array> | undefined;
+
+    return {
+      id: `${session.id}:${Date.now()}`,
+      raw: handle,
+      write: async (input: string) => {
+        if (!stdinWriter) {
+          stdinWriter = handle.stdin.getWriter();
+        }
+        await stdinWriter.write(encoder.encode(input));
+      },
+      wait: () => settled,
+      kill: async () => {
+        await handle.kill().catch(() => undefined);
+        queue.push({
+          type: "exit",
+          exitCode: 137,
+          timestamp: new Date().toISOString(),
+        });
+        queue.finish();
+        killedResolve?.({
+          exitCode: 137,
+          stdout,
+          stderr,
+          combinedOutput: `${stdout}${stderr}`,
+          raw: handle,
+        });
+      },
+      [Symbol.asyncIterator]: () => queue[Symbol.asyncIterator](),
+    };
+  }
+
+  override async uploadFile(
+    content: Buffer | string,
+    targetPath: string,
+  ): Promise<void> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+    const target = this.resolveSandboxPath(targetPath);
+    const data =
+      typeof content === "string"
+        ? encoder.encode(content)
+        : new Uint8Array(content);
+
+    if (isUnderFsRoot(target)) {
+      await session.writeFile(target, data);
+      return;
+    }
+
+    const dir = path.posix.dirname(target);
+    const result = await session.run(
+      [
+        "/bin/sh",
+        "-c",
+        `mkdir -p ${shellQuote(dir)} && cat > ${shellQuote(target)}`,
+      ],
+      { stdin: bytesToStream(data) },
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to upload file to Tenki sandbox at ${target} ` +
+          `(exit ${result.exitCode}): ${decoder.decode(result.stderr).trim()}`,
+      );
+    }
+  }
+
+  override async downloadFile(sourcePath: string): Promise<Buffer> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+    const source = this.resolveSandboxPath(sourcePath);
+
+    if (isUnderFsRoot(source)) {
+      return Buffer.from(await session.readFile(source));
+    }
+
+    const result = await session.run([
+      "/bin/sh",
+      "-c",
+      `cat -- ${shellQuote(source)}`,
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to download file from Tenki sandbox at ${source} ` +
+          `(exit ${result.exitCode}): ${decoder.decode(result.stderr).trim()}`,
+      );
+    }
+    return Buffer.from(result.stdout);
+  }
+
+  private resolveSandboxPath(filePath: string): string {
+    return path.posix.isAbsolute(filePath)
+      ? filePath
+      : path.posix.join(this.workingDir, filePath);
+  }
+
+  async list(options?: SandboxListOptions): Promise<SandboxDescriptor[]> {
+    const filterTags = options?.tags ?? this.getTags();
+    const sessions = await this.client.list({ tags: [this.providerMarker()] });
+
+    return sessions
+      .filter((session) => matchesAllTags(session.metadata, filterTags))
+      .map((session) => ({
+        provider: this.provider,
+        id: session.id,
+        state: session.state,
+        tags: { ...session.metadata },
+        raw: session,
+      }));
+  }
+
+  async snapshot(): Promise<string | null> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+    const snap = await this.client.createSnapshotAndWait(session.id);
+    return snap.id ?? null;
+  }
+
+  async stop(): Promise<void> {
+    if (this.session) {
+      await this.session.pause();
+    }
+  }
+
+  async delete(): Promise<void> {
+    const session = this.session;
+    this.session = undefined;
+    this.previewLinks.clear();
+    if (session) {
+      await session.close().catch(() => undefined);
+    }
+    this.closeClient();
+  }
+
+  async openPort(port: number): Promise<void> {
+    this.requireProvisioned();
+    const session = this.requireSession();
+    const exposed = await session.exposePort(port, this.previewPortOptions());
+    this.previewLinks.set(port, exposed.previewUrl);
+  }
+
+  async getPreviewLink(port: number): Promise<string> {
+    this.requireProvisioned();
+    const cached = this.previewLinks.get(port);
+    if (cached) {
+      return cached;
+    }
+    const session = this.requireSession();
+    const exposed = await session.exposePort(port, this.previewPortOptions());
+    this.previewLinks.set(port, exposed.previewUrl);
+    return exposed.previewUrl;
+  }
+
+  private previewPortOptions(): { ttlMs: number } | undefined {
+    const ttlMs = this.options.provider?.previewTtlMs;
+    return ttlMs ? { ttlMs } : undefined;
+  }
+
+  private async findMatchingSession(
+    desiredTags: Record<string, string>,
+  ): Promise<Session | undefined> {
+    try {
+      const sessions = await this.client.list({
+        tags: [this.providerMarker()],
+      });
+      return sessions.find(
+        (session) =>
+          !isTerminal(session.state) &&
+          matchesAllTags(session.metadata, desiredTags),
+      );
+    } catch (error) {
+      debugSandbox("tenki warm-reuse lookup failed: %o", error);
+      return undefined;
+    }
+  }
+
+  private getTags(): Record<string, string> {
+    return {
+      "agentbox.provider": this.provider,
+      ...(this.options.tags ?? {}),
+    };
+  }
+
+  private providerMarker(): string {
+    return `agentbox.provider:${this.provider}`;
+  }
+
+  private closeClient(): void {
+    if (this.clientClosed) {
+      return;
+    }
+    this.clientClosed = true;
+    try {
+      this.client.close();
+    } catch {
+      return;
+    }
+  }
+
+  private requireSession(): Session {
+    if (!this.session) {
+      throw new Error("Tenki sandbox has not been provisioned.");
+    }
+    return this.session;
+  }
+}

--- a/src/sandboxes/providers/tenki.ts
+++ b/src/sandboxes/providers/tenki.ts
@@ -76,7 +76,6 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
   private readonly client: TenkiClient;
   private session?: Session;
   private clientClosed = false;
-  private projectContext?: { workspaceId?: string; projectId?: string };
   private readonly previewLinks = new Map<number, string>();
 
   constructor(options: TenkiSandboxOptions) {
@@ -169,12 +168,8 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
       createOptions.maxDurationMs = this.options.autoStopMs;
     }
 
-    const context = await this.resolveProjectContext();
-    if (context.workspaceId !== undefined) {
-      createOptions.workspaceId = context.workspaceId;
-    }
-    if (context.projectId !== undefined) {
-      createOptions.projectId = context.projectId;
+    if (provider?.workspaceId !== undefined) {
+      createOptions.workspaceId = provider.workspaceId;
     }
 
     const session = await this.client.createAndWait(createOptions);
@@ -197,41 +192,6 @@ export class TenkiSandboxAdapter extends SandboxAdapter<
         );
       }
     }
-  }
-
-  private async resolveProjectContext(): Promise<{
-    workspaceId?: string;
-    projectId?: string;
-  }> {
-    const provider = this.options.provider;
-    if (provider?.projectId) {
-      return {
-        workspaceId: provider.workspaceId,
-        projectId: provider.projectId,
-      };
-    }
-    if (this.projectContext) {
-      return this.projectContext;
-    }
-
-    const identity = await this.client.whoAmI();
-    const workspace =
-      (provider?.workspaceId
-        ? identity.workspaces.find((w) => w.id === provider.workspaceId)
-        : undefined) ?? identity.workspaces[0];
-    const project = workspace?.projects[0];
-    if (!workspace || !project) {
-      throw new Error(
-        "Tenki: could not resolve a default project. " +
-          "Set `provider.projectId` (and optionally `provider.workspaceId`).",
-      );
-    }
-
-    this.projectContext = {
-      workspaceId: workspace.id,
-      projectId: project.id,
-    };
-    return this.projectContext;
   }
 
   async run(

--- a/src/sandboxes/types.ts
+++ b/src/sandboxes/types.ts
@@ -169,7 +169,6 @@ export interface TenkiProviderOptions {
   authToken?: string;
   baseUrl?: string;
   workspaceId?: string;
-  projectId?: string;
   name?: string;
   cpuCores?: number;
   memoryMb?: number;

--- a/src/sandboxes/types.ts
+++ b/src/sandboxes/types.ts
@@ -5,6 +5,7 @@ import type {
   CreateSandboxFromImageParams,
   CreateSandboxFromSnapshotParams,
 } from "@daytonaio/sdk";
+import type { CreateOptions as TenkiCreateOptions } from "@tenkicloud/sandbox";
 
 export type SandboxProviderName = SandboxProvider;
 
@@ -163,6 +164,23 @@ export interface VercelProviderOptions {
   protectionBypass?: string;
 }
 
+export interface TenkiProviderOptions {
+  apiKey?: string;
+  authToken?: string;
+  baseUrl?: string;
+  workspaceId?: string;
+  projectId?: string;
+  name?: string;
+  cpuCores?: number;
+  memoryMb?: number;
+  allowInbound?: boolean;
+  allowOutbound?: boolean;
+  sshAuthorizedKeys?: string[];
+  snapshotId?: string;
+  previewTtlMs?: number;
+  createParams?: Partial<TenkiCreateOptions>;
+}
+
 export interface E2bProviderOptions {
   apiKey?: string;
   accessToken?: string;
@@ -201,12 +219,17 @@ export interface E2bSandboxOptions extends SandboxOptionsBase {
   provider?: E2bProviderOptions;
 }
 
+export interface TenkiSandboxOptions extends SandboxOptionsBase {
+  provider?: TenkiProviderOptions;
+}
+
 export type SandboxOptionsMap = {
   "local-docker": LocalDockerSandboxOptions;
   modal: ModalSandboxOptions;
   daytona: DaytonaSandboxOptions;
   vercel: VercelSandboxOptions;
   e2b: E2bSandboxOptions;
+  tenki: TenkiSandboxOptions;
 };
 
 export type SandboxOptions<
@@ -219,6 +242,7 @@ export type SandboxRawMap = {
   daytona: import("./providers/daytona").DaytonaRaw;
   vercel: import("./providers/vercel").VercelRaw;
   e2b: import("./providers/e2b").E2bRaw;
+  tenki: import("./providers/tenki").TenkiRaw;
 };
 
 export type SandboxRaw<P extends SandboxProviderName = SandboxProviderName> =

--- a/test/helpers/live-matrix-e2e.ts
+++ b/test/helpers/live-matrix-e2e.ts
@@ -16,7 +16,7 @@ import { buildSandboxImage } from "../../src/sandbox-images/build";
 
 export type LiveMatrixSandboxProvider = Extract<
   SandboxProviderName,
-  "local-docker" | "modal" | "daytona" | "e2b" | "vercel"
+  "local-docker" | "modal" | "daytona" | "e2b" | "vercel" | "tenki"
 >;
 
 export type LiveMatrixAgentProvider = AgentProviderName;
@@ -60,6 +60,7 @@ export const LIVE_MATRIX_SANDBOX_PROVIDERS = [
   SandboxProvider.Daytona,
   SandboxProvider.E2B,
   SandboxProvider.Vercel,
+  SandboxProvider.Tenki,
 ] as const satisfies readonly LiveMatrixSandboxProvider[];
 
 export const LIVE_MATRIX_AGENT_PROVIDERS = [
@@ -303,6 +304,16 @@ function getSandboxSkipReason(
     return null;
   }
 
+  if (sandboxProvider === SandboxProvider.Tenki) {
+    if (!ROOT_ENV.TENKI_API_KEY && !ROOT_ENV.TENKI_AUTH_TOKEN) {
+      return "requires TENKI_API_KEY or TENKI_AUTH_TOKEN.";
+    }
+    if (!ROOT_ENV.AGENTBOX_TENKI_IMAGE) {
+      return "requires AGENTBOX_TENKI_IMAGE (a Tenki registry image with the agent CLIs installed).";
+    }
+    return null;
+  }
+
   if (!ROOT_ENV.E2B_API_KEY) {
     return "requires E2B_API_KEY or E2B_ACCESS_TOKEN.";
   }
@@ -398,6 +409,12 @@ async function resolveSandboxImage(
         return ROOT_ENV.AGENTBOX_VERCEL_SNAPSHOT_ID;
       }
       return buildVercelMatrixSnapshot();
+    }
+
+    if (sandboxProvider === SandboxProvider.Tenki) {
+      // Tenki boots from a registry image ref rather than an agentbox-built
+      // image; the skip logic guarantees AGENTBOX_TENKI_IMAGE is set here.
+      return ROOT_ENV.AGENTBOX_TENKI_IMAGE!;
     }
 
     return buildSandboxImage({
@@ -518,6 +535,31 @@ function createSandboxForCombination(
           : {}),
         ...(ROOT_ENV.VERCEL_PROTECTION_BYPASS
           ? { protectionBypass: ROOT_ENV.VERCEL_PROTECTION_BYPASS }
+          : {}),
+      },
+    });
+  }
+
+  if (combination.sandboxProvider === SandboxProvider.Tenki) {
+    return new Sandbox(SandboxProvider.Tenki, {
+      workingDir: "/workspace",
+      image,
+      tags,
+      env: COMMON_SANDBOX_ENV,
+      idleTimeoutMs: 15 * 60_000,
+      resources: {
+        cpu: 2,
+        memoryMiB: 4096,
+      },
+      provider: {
+        allowInbound: true,
+        allowOutbound: true,
+        ...(ROOT_ENV.TENKI_API_KEY ? { apiKey: ROOT_ENV.TENKI_API_KEY } : {}),
+        ...(ROOT_ENV.TENKI_AUTH_TOKEN
+          ? { authToken: ROOT_ENV.TENKI_AUTH_TOKEN }
+          : {}),
+        ...(ROOT_ENV.TENKI_BASE_URL
+          ? { baseUrl: ROOT_ENV.TENKI_BASE_URL }
           : {}),
       },
     });

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -72,6 +72,21 @@ describe.skipIf(!smokeEnabled)("optional provider smoke tests", () => {
     expect(Array.isArray(sandboxes)).toBe(true);
   });
 
+  it("can list Tenki sandboxes when credentials are present", async () => {
+    if (!process.env.TENKI_API_KEY && !process.env.TENKI_AUTH_TOKEN) {
+      return;
+    }
+
+    const sandbox = new Sandbox(SandboxProvider.Tenki, {
+      provider: {
+        apiKey: process.env.TENKI_API_KEY ?? process.env.TENKI_AUTH_TOKEN,
+      },
+    });
+
+    const sandboxes = await sandbox.list();
+    expect(Array.isArray(sandboxes)).toBe(true);
+  });
+
   it("can list E2B sandboxes when credentials are present", async () => {
     if (!process.env.E2B_API_KEY) {
       return;

--- a/test/tenki-sandbox.test.ts
+++ b/test/tenki-sandbox.test.ts
@@ -1,0 +1,520 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createAndWait: vi.fn(),
+  list: vi.fn(),
+  createSnapshotAndWait: vi.fn(),
+  clientClose: vi.fn(),
+  clientCtor: vi.fn(),
+}));
+
+vi.mock("@tenkicloud/sandbox", () => {
+  class SessionNotFoundError extends Error {
+    name = "SessionNotFoundError";
+  }
+  class TenkiSandbox {
+    createAndWait = mocks.createAndWait;
+    list = mocks.list;
+    createSnapshotAndWait = mocks.createSnapshotAndWait;
+    close = mocks.clientClose;
+    constructor(options: unknown) {
+      mocks.clientCtor(options);
+    }
+  }
+  return { TenkiSandbox, SessionNotFoundError };
+});
+
+import { Sandbox, SandboxProvider } from "../src";
+
+const enc = new TextEncoder();
+const MARKER_TAGS = { "agentbox.provider": "tenki" };
+
+type HandleOptions = {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  hang?: boolean;
+};
+
+function makeHandle(options: HandleOptions = {}) {
+  const { stdout = "", stderr = "", exitCode = 0, hang = false } = options;
+
+  const stream = (content: string) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (content) {
+          controller.enqueue(enc.encode(content));
+        }
+        if (!hang) {
+          controller.close();
+        }
+      },
+    });
+
+  const result = {
+    exitCode,
+    stdout: enc.encode(stdout),
+    stderr: enc.encode(stderr),
+  };
+  let resolveResult!: (value: typeof result) => void;
+  const resultPromise = new Promise<typeof result>((resolve) => {
+    resolveResult = resolve;
+  });
+  if (!hang) {
+    resolveResult(result);
+  }
+
+  const writes: Uint8Array[] = [];
+
+  return {
+    stdout: stream(stdout),
+    stderr: stream(stderr),
+    stdin: new WritableStream<Uint8Array>({
+      write(chunk) {
+        writes.push(chunk);
+      },
+    }),
+    pid: Promise.resolve(1),
+    kill: vi.fn(async () => {}),
+    then<T, R>(
+      onfulfilled?: ((value: typeof result) => T | PromiseLike<T>) | null,
+      onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null,
+    ) {
+      return resultPromise.then(onfulfilled, onrejected);
+    },
+    _writes: writes,
+  };
+}
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sess-123",
+    state: "RUNNING",
+    metadata: { ...MARKER_TAGS },
+    run: vi.fn(() => makeHandle({ stdout: "ok\n" })),
+    exposePort: vi.fn(async (port: number) => ({
+      port,
+      previewUrl: `https://preview.tenki.sh/${port}`,
+    })),
+    writeFile: vi.fn(async () => {}),
+    readFile: vi.fn(async () => enc.encode("file-body")),
+    resume: vi.fn(async () => {}),
+    waitReady: vi.fn(async () => {}),
+    pause: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function makeSandbox(options: Record<string, unknown> = {}) {
+  return new Sandbox(SandboxProvider.Tenki, {
+    provider: { apiKey: "tk_test" },
+    ...options,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.list.mockResolvedValue([]);
+});
+
+describe("lifecycle", () => {
+  it("provisions via createAndWait with metadata, marker tag, and defaults", async () => {
+    const session = makeSession();
+    mocks.createAndWait.mockResolvedValue(session);
+
+    const sb = makeSandbox({ tags: { scope: "test" } });
+    await sb.findOrProvision();
+
+    expect(mocks.clientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ authToken: "tk_test" }),
+    );
+    expect(mocks.createAndWait).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowInbound: true,
+        allowOutbound: true,
+        metadata: { ...MARKER_TAGS, scope: "test" },
+        tags: ["agentbox.provider:tenki"],
+      }),
+    );
+    expect(sb.id).toBe("sess-123");
+    expect(sb.isWarm).toBe(false);
+  });
+
+  it("creates a non-default working directory with a privileged run", async () => {
+    const run = vi.fn(() => makeHandle());
+    mocks.createAndWait.mockResolvedValue(makeSession({ run }));
+
+    const sb = makeSandbox({ workingDir: "/workspace" });
+    await sb.findOrProvision();
+
+    expect(run).toHaveBeenCalledWith(
+      ["/bin/sh", "-c", expect.stringContaining("mkdir -p '/workspace'")],
+      { privileged: true },
+    );
+  });
+
+  it("closes the fresh session when working-directory setup fails", async () => {
+    const session = makeSession({
+      run: vi.fn(() => makeHandle({ exitCode: 1, stderr: "mkdir: denied" })),
+    });
+    mocks.createAndWait.mockResolvedValue(session);
+
+    const sb = makeSandbox({ workingDir: "/workspace" });
+    await expect(sb.findOrProvision()).rejects.toThrow(/working directory/);
+    expect(session.close).toHaveBeenCalledTimes(1);
+    expect(sb.id).toBeUndefined();
+  });
+
+  it("warm-reuses a RUNNING session without resuming", async () => {
+    const session = makeSession();
+    mocks.list.mockResolvedValue([session]);
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    expect(sb.isWarm).toBe(true);
+    expect(sb.id).toBe("sess-123");
+    expect(session.resume).not.toHaveBeenCalled();
+    expect(session.waitReady).not.toHaveBeenCalled();
+    expect(mocks.createAndWait).not.toHaveBeenCalled();
+  });
+
+  it("resumes only PAUSED sessions and waits on transitional ones", async () => {
+    for (const [state, expected] of [
+      ["PAUSED", "resume"],
+      ["CREATING", "waitReady"],
+      ["RESUMING", "waitReady"],
+    ] as const) {
+      vi.clearAllMocks();
+      const session = makeSession({ state });
+      mocks.list.mockResolvedValue([session]);
+
+      const sb = makeSandbox();
+      await sb.findOrProvision();
+
+      expect(session.resume).toHaveBeenCalledTimes(expected === "resume" ? 1 : 0);
+      expect(session.waitReady).toHaveBeenCalledTimes(
+        expected === "waitReady" ? 1 : 0,
+      );
+    }
+  });
+
+  it("does not warm-reuse PAUSING or terminal sessions", async () => {
+    const pausing = makeSession({ state: "PAUSING" });
+    const terminated = makeSession({ state: "TERMINATED" });
+    mocks.list.mockResolvedValue([pausing, terminated]);
+    const fresh = makeSession({ id: "sess-new" });
+    mocks.createAndWait.mockResolvedValue(fresh);
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    expect(sb.id).toBe("sess-new");
+    expect(sb.isWarm).toBe(false);
+  });
+
+  it("propagates lookup failures instead of creating another sandbox", async () => {
+    mocks.list.mockRejectedValue(new Error("auth expired"));
+
+    const sb = makeSandbox();
+    await expect(sb.findOrProvision()).rejects.toThrow("auth expired");
+    expect(mocks.createAndWait).not.toHaveBeenCalled();
+  });
+
+  it("pauses on stop and closes session + client on delete", async () => {
+    const session = makeSession();
+    mocks.createAndWait.mockResolvedValue(session);
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    await sb.stop();
+    expect(session.pause).toHaveBeenCalled();
+
+    await sb.delete();
+    expect(session.close).toHaveBeenCalled();
+    expect(mocks.clientClose).toHaveBeenCalled();
+  });
+
+  it("keeps the session reference when close() fails so delete can be retried", async () => {
+    let closeCalls = 0;
+    const session = makeSession({
+      close: vi.fn(async () => {
+        closeCalls++;
+        if (closeCalls === 1) {
+          throw new Error("network blip");
+        }
+      }),
+    });
+    mocks.createAndWait.mockResolvedValue(session);
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    await expect(sb.delete()).rejects.toThrow("network blip");
+    expect(sb.id).toBe("sess-123");
+
+    await sb.delete();
+    expect(sb.id).toBeUndefined();
+    expect(closeCalls).toBe(2);
+  });
+
+  it("treats an already-gone session as successfully deleted", async () => {
+    const { SessionNotFoundError } = await import("@tenkicloud/sandbox");
+    const session = makeSession({
+      close: vi.fn(async () => {
+        throw new SessionNotFoundError("gone");
+      }),
+    });
+    mocks.createAndWait.mockResolvedValue(session);
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    await sb.delete();
+    expect(sb.id).toBeUndefined();
+  });
+
+  it("snapshots via createSnapshotAndWait", async () => {
+    mocks.createAndWait.mockResolvedValue(makeSession());
+    mocks.createSnapshotAndWait.mockResolvedValue({ id: "snap-1" });
+
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    expect(await sb.snapshot()).toBe("snap-1");
+    expect(mocks.createSnapshotAndWait).toHaveBeenCalledWith("sess-123");
+  });
+
+  it("lists sessions filtered by tags mirrored into metadata", async () => {
+    const mine = makeSession({ metadata: { ...MARKER_TAGS, scope: "a" } });
+    const other = makeSession({
+      id: "sess-other",
+      metadata: { ...MARKER_TAGS, scope: "b" },
+    });
+    mocks.list.mockResolvedValue([mine, other]);
+
+    const sb = makeSandbox({ tags: { scope: "a" } });
+    const descriptors = await sb.list();
+
+    expect(mocks.list).toHaveBeenCalledWith({
+      tags: ["agentbox.provider:tenki"],
+    });
+    expect(descriptors).toHaveLength(1);
+    expect(descriptors[0]).toMatchObject({
+      provider: "tenki",
+      id: "sess-123",
+      state: "RUNNING",
+      tags: { ...MARKER_TAGS, scope: "a" },
+    });
+  });
+});
+
+describe("run", () => {
+  async function provisioned(session: ReturnType<typeof makeSession>) {
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+    return sb;
+  }
+
+  it("maps stdout, stderr, and exit code", async () => {
+    const sb = await provisioned(
+      makeSession({
+        run: vi.fn(() => makeHandle({ stdout: "out", stderr: "err", exitCode: 7 })),
+      }),
+    );
+
+    const result = await sb.run("false");
+    expect(result.exitCode).toBe(7);
+    expect(result.stdout).toBe("out");
+    expect(result.stderr).toBe("err");
+    expect(result.combinedOutput).toBe("outerr");
+  });
+
+  it("wraps commands in a shell and forwards cwd + merged env", async () => {
+    const run = vi.fn(() => makeHandle({ stdout: "ok" }));
+    mocks.createAndWait.mockResolvedValue(makeSession({ run }));
+    const sb = makeSandbox({ env: { BASE: "1" } });
+    await sb.findOrProvision();
+
+    await sb.run(["echo", "hello world"], { cwd: "/tmp", env: { EXTRA: "2" } });
+
+    expect(run).toHaveBeenCalledWith(
+      ["/bin/sh", "-lc", "'echo' 'hello world'"],
+      { cwd: "/tmp", env: { BASE: "1", EXTRA: "2" } },
+    );
+  });
+
+  it("enforces timeoutMs: rejects promptly and kills the process", async () => {
+    const handle = makeHandle({ hang: true });
+    const sb = await provisioned(makeSession({ run: vi.fn(() => handle) }));
+
+    const start = Date.now();
+    await expect(sb.run("sleep 60", { timeoutMs: 50 })).rejects.toThrow(
+      /timed out after 50ms/,
+    );
+    expect(Date.now() - start).toBeLessThan(1_000);
+    expect(handle.kill).toHaveBeenCalled();
+  });
+});
+
+describe("runAsync", () => {
+  async function provisioned(session: ReturnType<typeof makeSession>) {
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+    return sb;
+  }
+
+  it("streams stdout events and delivers the exit event", async () => {
+    const sb = await provisioned(
+      makeSession({ run: vi.fn(() => makeHandle({ stdout: "tick" })) }),
+    );
+
+    const handle = await sb.runAsync("emit");
+    const chunks: string[] = [];
+    let exitCode: number | undefined;
+    for await (const event of handle) {
+      if (event.type === "stdout" && event.chunk) chunks.push(event.chunk);
+      if (event.type === "exit") exitCode = event.exitCode;
+    }
+
+    expect(chunks.join("")).toBe("tick");
+    expect(exitCode).toBe(0);
+    expect((await handle.wait()).exitCode).toBe(0);
+  });
+
+  it("forwards write() input to the process stdin", async () => {
+    const raw = makeHandle({ stdout: "ok" });
+    const sb = await provisioned(makeSession({ run: vi.fn(() => raw) }));
+
+    const handle = await sb.runAsync("cat");
+    await handle.write!("ping\n");
+
+    expect(new TextDecoder().decode(raw._writes[0])).toBe("ping\n");
+  });
+
+  it("kill() settles wait() immediately with exit 137", async () => {
+    const raw = makeHandle({ hang: true });
+    const sb = await provisioned(makeSession({ run: vi.fn(() => raw) }));
+
+    const handle = await sb.runAsync("sleep 120");
+    const start = Date.now();
+    await handle.kill();
+    const result = await handle.wait();
+
+    expect(Date.now() - start).toBeLessThan(1_000);
+    expect(result.exitCode).toBe(137);
+    expect(raw.kill).toHaveBeenCalled();
+  });
+
+  it("enforces timeoutMs: wait() rejects, iterator surfaces the error, process killed", async () => {
+    const raw = makeHandle({ hang: true });
+    const sb = await provisioned(makeSession({ run: vi.fn(() => raw) }));
+
+    const handle = await sb.runAsync("sleep 60", { timeoutMs: 50 });
+    await expect(handle.wait()).rejects.toThrow(/timed out after 50ms/);
+    expect(raw.kill).toHaveBeenCalled();
+
+    await expect(async () => {
+      for await (const event of handle) void event;
+    }).rejects.toThrow(/timed out/);
+  });
+
+  it("does not time out commands that finish in time", async () => {
+    const raw = makeHandle({ stdout: "fast" });
+    const sb = await provisioned(makeSession({ run: vi.fn(() => raw) }));
+
+    const handle = await sb.runAsync("true", { timeoutMs: 5_000 });
+    const result = await handle.wait();
+
+    expect(result.exitCode).toBe(0);
+    expect(raw.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe("files", () => {
+  it("uses the data-plane API inside /home/tenki and resolves relative paths", async () => {
+    const session = makeSession();
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    await sb.uploadFile("hello", "notes.txt");
+    expect(session.writeFile).toHaveBeenCalledWith(
+      "/home/tenki/notes.txt",
+      enc.encode("hello"),
+    );
+
+    const body = await sb.downloadFile("notes.txt");
+    expect(session.readFile).toHaveBeenCalledWith("/home/tenki/notes.txt");
+    expect(body.toString("utf8")).toBe("file-body");
+  });
+
+  it("falls back to a shell pipe for paths outside /home/tenki", async () => {
+    const run = vi.fn(() => makeHandle({ stdout: "shell-body" }));
+    const session = makeSession({ run });
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox({ workingDir: "/workspace" });
+    await sb.findOrProvision();
+    run.mockClear();
+
+    await sb.uploadFile("data", "artifact.bin");
+    expect(session.writeFile).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledWith(
+      [
+        "/bin/sh",
+        "-c",
+        "mkdir -p '/workspace' && cat > '/workspace/artifact.bin'",
+      ],
+      { stdin: expect.any(ReadableStream) },
+    );
+
+    const body = await sb.downloadFile("/workspace/artifact.bin");
+    expect(session.readFile).not.toHaveBeenCalled();
+    expect(body.toString("utf8")).toBe("shell-body");
+  });
+});
+
+describe("preview links", () => {
+  it("caches the URL and refreshes it after expiry", async () => {
+    let exposes = 0;
+    const session = makeSession({
+      exposePort: vi.fn(async (port: number) => {
+        exposes++;
+        return {
+          port,
+          previewUrl: `https://p${exposes}.tenki.sh`,
+          expiresAt: new Date(Date.now() + 5_100),
+        };
+      }),
+    });
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    const first = await sb.getPreviewLink(3000);
+    const second = await sb.getPreviewLink(3000);
+    expect(first).toBe(second);
+    expect(exposes).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const third = await sb.getPreviewLink(3000);
+    expect(third).not.toBe(first);
+    expect(exposes).toBe(2);
+  });
+
+  it("keeps URLs without expiry cached", async () => {
+    const session = makeSession();
+    mocks.createAndWait.mockResolvedValue(session);
+    const sb = makeSandbox();
+    await sb.findOrProvision();
+
+    await sb.openPort(3000);
+    const url = await sb.getPreviewLink(3000);
+    expect(url).toBe("https://preview.tenki.sh/3000");
+    expect(session.exposePort).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
  This PR adds [Tenki](https://tenki.cloud) as a new sandbox provider, so agents can run inside Tenki's
  Linux microVMs the same way they already do on Modal, E2B, Daytona, Vercel, and local Docker.

  ## Usage

  ```ts
  const sandbox = new Sandbox("tenki", {
    workingDir: "/workspace",
    provider: { apiKey: process.env.TENKI_API_KEY },
  });

  await sandbox.findOrProvision();
  const result = await sandbox.run("uname -a");

  The API key can also come from the TENKI_API_KEY env var. Everything else works like the other
  providers: run/runAsync, file upload/download, gitClone, preview URLs, snapshots, pause/resume, and
  warm reuse of tagged sandboxes.

  Things worth knowing

  A few Tenki-specific behaviors are handled inside the adapter so callers don't have to think about
  them:

  - Tenki only allows simple lowercase tags, so the usual agentbox tag map is stored in session
  metadata instead, with one marker tag for server-side filtering.
  - Tenki has no server-side command timeout, so timeoutMs is enforced by the adapter. kill() always
  returns immediately instead of waiting for stray child processes.
  - Tenki's file API only works under /home/tenki. Files outside it (like /workspace) are transferred
  through the shell instead, and a custom workingDir is created automatically when the sandbox starts.
  - Preview URLs are cached and refreshed before they expire.

  Testing

  Ran a full live test against the real Tenki API covering every adapter method — command execution
  (exit codes, env, cwd, timeouts), streaming with stdin and kill, text and binary file round-trips,
  gitClone, a preview URL actually fetched over HTTPS, warm reuse, snapshot, pause→resume, and
  teardown. Also verified separately with workingDir: "/workspace", and confirmed real usage showed up
  in the Tenki billing dashboard.